### PR TITLE
karm-print: parametrize stock paper size with scale

### DIFF
--- a/src/libs/karm-print/file-printer.h
+++ b/src/libs/karm-print/file-printer.h
@@ -1,10 +1,15 @@
 #pragma once
 
 #include <karm-print/printer.h>
+#include <vaev-base/resolution.h>
 
 namespace Karm::Print {
 
 struct FilePrinter : public Printer {
+    Vaev::Resolution _scale;
+
+    FilePrinter(Vaev::Resolution scale) : _scale(scale) {}
+
     virtual Res<> write(Io::Writer &w) = 0;
 };
 

--- a/src/libs/karm-print/image-printer.h
+++ b/src/libs/karm-print/image-printer.h
@@ -13,11 +13,14 @@ struct ImagePrinter : public FilePrinter {
     Opt<Gfx::CpuCanvas> _canvas;
     Image::Saver _saver;
 
-    ImagePrinter(Image::Saver saver = {})
-        : _saver(saver) {}
+    ImagePrinter(Vaev::Resolution scale = Vaev::Resolution::fromDppx(1), Image::Saver saver = {})
+        : FilePrinter(scale), _saver(saver) {}
 
     Gfx::Canvas &beginPage(PaperStock paper) override {
-        _pages.emplaceBack(Gfx::Surface::alloc(paper.size().cast<isize>(), Gfx::RGBA8888));
+        _pages.emplaceBack(Gfx::Surface::alloc(
+            (paper.size() * _scale.toDppx()).cast<isize>(),
+            Gfx::RGBA8888
+        ));
 
         if (_canvas)
             _canvas->end();

--- a/src/libs/karm-print/pdf-printer.h
+++ b/src/libs/karm-print/pdf-printer.h
@@ -16,9 +16,12 @@ struct PdfPrinter : public FilePrinter {
     Vec<PdfPage> _pages;
     Opt<Pdf::Canvas> _canvas;
 
+    PdfPrinter(Vaev::Resolution scale = Vaev::Resolution::fromDppx(1))
+        : FilePrinter(scale) {}
+
     Gfx::Canvas &beginPage(PaperStock paper) override {
         auto &page = _pages.emplaceBack(paper);
-        _canvas = Pdf::Canvas{page.data, paper.size()};
+        _canvas = Pdf::Canvas{page.data, paper.size() * _scale.toDppx()};
         return *_canvas;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,8 +153,8 @@ Res<> print(Mime::Url const &, Strong<Markup::Document> dom, Io::Writer &output,
 
     Strong<Print::FilePrinter> printer =
         options.printToBMP
-            ? Strong<Print::FilePrinter>{makeStrong<Print::ImagePrinter>()}
-            : makeStrong<Print::PdfPrinter>();
+            ? Strong<Print::FilePrinter>{makeStrong<Print::ImagePrinter>(options.scale)}
+            : makeStrong<Print::PdfPrinter>(options.scale);
 
     for (auto &page : pages) {
         page->print(


### PR DESCRIPTION
The Print::PaperStock _paper attribute from Karm::Scene::Page is sized taking the scale parameter into account; however, this should not be the size of the paper when printing, that is, we should use the original paper size, not the scaled one.

This commit couples the scaling logic to the printing classes, allowing the _paper attribute from Karm::Scene::Page to be sized back to its original size and thus the correct dimenions of the printing paper to be used.