### PR TITLE
meta: Removed useless on: pull_request from workflows.

### DIFF
--- a/.github/workflows/check-darwin.yml
+++ b/.github/workflows/check-darwin.yml
@@ -1,6 +1,6 @@
 name: Checks (Darwin)
 
-on: [ push, pull_request, workflow_dispatch ]
+on: [ push, workflow_dispatch ]
 
 jobs:
   build-all:

--- a/.github/workflows/checks-linux.yml
+++ b/.github/workflows/checks-linux.yml
@@ -1,6 +1,6 @@
 name: Checks (Ubuntu)
 
-on: [ push, pull_request, workflow_dispatch ]
+on: [ push, workflow_dispatch ]
 
 jobs:
   ubuntu:


### PR DESCRIPTION
It was causing duplicated workflow runs.