### PR TITLE
vaev-style: Improved the SpecifiedValues struct layout.

### DIFF
--- a/src/vaev-engine/layout/paint.cpp
+++ b/src/vaev-engine/layout/paint.cpp
@@ -9,7 +9,6 @@ import Karm.Logger;
 import Karm.Math;
 import Karm.Scene;
 
-
 import :style;
 import :values;
 import :layout.base;
@@ -75,7 +74,7 @@ Opt<Gfx::Outline> buildOutline(Metrics const& metrics, Style::SpecifiedValues co
 
 static bool _needsNewStackingContext(Frag const& frag) {
     return frag.style().zIndex != Keywords::AUTO or
-           frag.style().clip.has() or
+           frag.style().clip->has() or
            frag.style().transform->has() or
            frag.style().opacity != 1.0;
 }
@@ -285,7 +284,7 @@ static Math::Vec2f _resolveBackgroundPosition(Resolver& resolver, BackgroundPosi
 
 static Rc<Scene::Clip> _applyClip(Frag const& frag, Rc<Scene::Node> content) {
     Math::Path result;
-    auto& clip = frag.style().clip.unwrap();
+    auto& clip = frag.style().clip->unwrap();
 
     // TODO: handle SVG cases (https://drafts.fxtf.org/css-masking/#typedef-geometry-box)
     auto [referenceBox, radii] = clip.referenceBox.visit(Visitor{
@@ -665,7 +664,7 @@ static void _establishStackingContext(Frag& frag, Scene::Stack& stack) {
     _paintStackingContext(frag, *innerStack);
 
     Rc<Scene::Node> out = innerStack;
-    if (frag.style().clip.has())
+    if (frag.style().clip->has())
         out = _applyClip(frag, out);
     if (frag.style().transform->has())
         out = _applyTransform(frag, out);

--- a/src/vaev-engine/style/props.cpp
+++ b/src/vaev-engine/style/props.cpp
@@ -1252,14 +1252,14 @@ export struct ClipPathProp {
 
     void apply(SpecifiedValues& c) const {
         if (auto clipShape = value.is<BasicShape>())
-            c.clip = *clipShape;
+            c.clip.cow() = *clipShape;
         else
-            c.clip = NONE;
+            c.clip.cow() = NONE;
     }
 
     static Value load(SpecifiedValues const& c) {
-        if (c.clip.has())
-            return c.clip.unwrap();
+        if (c.clip->has())
+            return c.clip->unwrap();
         return Keywords::NONE;
     }
 

--- a/src/vaev-engine/style/specified.cpp
+++ b/src/vaev-engine/style/specified.cpp
@@ -24,73 +24,53 @@ struct TransformProps {
     }
 };
 
+using ClipProps = Opt<BasicShape>;
+
 // https://www.w3.org/TR/css-cascade/#specified
 export struct SpecifiedValues {
     static SpecifiedValues const& initial();
 
     SpecifiedValues() : fontFace(Gfx::Fontface::fallback()) {}
 
-    Gfx::Color color;
-    Number opacity;
-    String content = ""s;
-
-    AlignProps aligns;
     Cow<Gaps> gaps;
-
     Cow<BackgroundProps> backgrounds;
     Cow<BorderProps> borders;
     Cow<Margin> margin = makeCow<Margin>(Width(CalcValue<PercentOr<Length>>(Length(0_au)))); // FIXME
     Cow<Outline> outline;
     Cow<Padding> padding = makeCow<Padding>(Length(0_au)); // FIXME
-    BoxSizing boxSizing;
     Cow<SizingProps> sizing;
-    Overflows overflows;
-    Opt<BasicShape> clip;
-
-    // CSS Inline Layout Module Level 3
-    // https://drafts.csswg.org/css-inline-3/
     Cow<Baseline> baseline;
-
-    // 9.3 Positioning schemes
-    // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
-    Position position;
     Cow<Offsets> offsets = makeCow<Offsets>(Width(Keywords::AUTO)); // FIXME
-
-    // CSS Writing Modes Level 3
-    // https://www.w3.org/TR/css-writing-modes-3
-    WritingMode writingMode;
-    Direction direction;
-
-    // CSS Display Module Level 3
-    // https://www.w3.org/TR/css-display-3
-    Display display;
-    Integer order;
-    Visibility visibility;
+    Cow<ClipProps> clip;
     Cow<TransformProps> transform;
-    // https://w3.org/TR/css-tables-3/#table-structure
     Cow<TableProps> table;
-
-    // CSS Fonts Module Level 4
-    // https://www.w3.org/TR/css-fonts-4/
     Cow<FontProps> font;
     Cow<TextProps> text;
-
     Cow<FlexProps> flex;
     Cow<BreakProps> break_;
-
-    Cow<Map<Symbol, Css::Content>> variables;
-
-    Float float_ = Float::NONE;
-    Clear clear = Clear::NONE;
-
-    // https://drafts.csswg.org/css2/#z-index
-    ZIndex zIndex = Keywords::AUTO;
-
     Cow<SVGProps> svg;
 
-    // ---------- Computed Style ---------------------
-
+    Cow<Map<Symbol, Css::Content>> variables;
     Rc<Gfx::Fontface> fontFace;
+
+    // Inlined fields
+    ZIndex zIndex = Keywords::AUTO;
+    Overflows overflows;
+    Gfx::Color color;
+    String content = ""s;
+    Integer order;
+    AlignProps aligns;
+    Display display;
+    f16 opacity;
+
+    // Small Field
+    Float float_ = Float::NONE;
+    Clear clear = Clear::NONE;
+    Visibility visibility;
+    WritingMode writingMode;
+    Direction direction;
+    Position position;
+    BoxSizing boxSizing;
 
     void inherit(SpecifiedValues const& parent) {
         color = parent.color;
@@ -99,11 +79,12 @@ export struct SpecifiedValues {
         variables = parent.variables;
         visibility = parent.visibility;
 
-        // FIXME: this is not clean and should be targeted by the styling refactor
-        svg.cow().fillOpacity = parent.svg->fillOpacity;
-        svg.cow().strokeWidth = parent.svg->strokeWidth;
-        svg.cow().fill = parent.svg->fill;
-        svg.cow().stroke = parent.svg->stroke;
+        if (not parent.svg.defaulted()) {
+            svg.cow().fillOpacity = parent.svg->fillOpacity;
+            svg.cow().strokeWidth = parent.svg->strokeWidth;
+            svg.cow().fill = parent.svg->fill;
+            svg.cow().stroke = parent.svg->stroke;
+        }
     }
 
     void setCustomProp(Str varName, Css::Content value) {

--- a/src/vaev-engine/values/breaks.cpp
+++ b/src/vaev-engine/values/breaks.cpp
@@ -71,7 +71,7 @@ struct ValueParser<BreakBetween> {
 // 3.2. Breaks Within Boxes: the break-inside property
 // https://www.w3.org/TR/css-break-3/#break-within
 
-export enum struct BreakInside {
+export enum struct BreakInside : u8 {
     AUTO,
     AVOID,
     AVOID_PAGE,

--- a/src/vaev-engine/values/float.cpp
+++ b/src/vaev-engine/values/float.cpp
@@ -12,7 +12,7 @@ namespace Vaev {
 
 // MARK: Clear & Float ---------------------------------------------------------
 
-export enum struct Float {
+export enum struct Float : u8 {
     NONE,
 
     INLINE_START,
@@ -45,7 +45,7 @@ struct ValueParser<Float> {
     }
 };
 
-export enum struct Clear {
+export enum struct Clear : u8 {
     NONE,
 
     LEFT,

--- a/src/vaev-engine/values/insets.cpp
+++ b/src/vaev-engine/values/insets.cpp
@@ -13,7 +13,7 @@ namespace Vaev {
 
 // MARK: Position --------------------------------------------------------------
 // https://www.w3.org/TR/CSS22/visuren.html#propdef-position
-export enum struct Position {
+export enum struct Position : u8 {
     STATIC,
 
     RELATIVE,

--- a/src/vaev-engine/values/overflow.cpp
+++ b/src/vaev-engine/values/overflow.cpp
@@ -11,7 +11,7 @@ namespace Vaev {
 
 // MARK: Overflow
 // https://www.w3.org/TR/css-overflow/#overflow-control
-export enum struct Overflow {
+export enum struct Overflow : u8 {
     VISIBLE,
     HIDDEN,
     SCROLL,

--- a/src/vaev-engine/values/svg.cpp
+++ b/src/vaev-engine/values/svg.cpp
@@ -64,12 +64,9 @@ export struct SVGProps {
 
     Number fillOpacity = 1;
     PercentOr<Length> strokeWidth = Length{1_au};
-
     Union<String, None> d = NONE;
-
     Paint fill = Color{Gfx::BLACK};
     Paint stroke = NONE;
-
     Opt<ViewBox> viewBox = NONE;
 
     void repr(Io::Emit& e) const {

--- a/src/vaev-engine/values/visibility.cpp
+++ b/src/vaev-engine/values/visibility.cpp
@@ -1,8 +1,12 @@
 export module Vaev.Engine:values.visibility;
 
+import Karm.Core;
+
+using namespace Karm;
+
 namespace Vaev {
 
-export enum struct Visibility {
+export enum struct Visibility : u8 {
     VISIBLE,
     HIDDEN,
     COLLAPSE,

--- a/src/vaev-engine/values/writing.cpp
+++ b/src/vaev-engine/values/writing.cpp
@@ -1,5 +1,9 @@
 export module Vaev.Engine:values.writing;
 
+import Karm.Core;
+
+using namespace Karm;
+
 namespace Vaev {
 
 // https://drafts.csswg.org/css-writing-modes-4/#inline-axis
@@ -40,14 +44,14 @@ export struct Axis {
 };
 
 // https://www.w3.org/TR/css-writing-modes-3/#propdef-writing-mode
-export enum struct WritingMode {
+export enum struct WritingMode : u8 {
     HORIZONTAL_TB,
     VERTICAL_RL,
     VERTICAL_LR,
 };
 
 // https://www.w3.org/TR/css-writing-modes-3/#propdef-direction
-export enum struct Direction {
+export enum struct Direction : u8 {
     LTR,
     RTL,
 };


### PR DESCRIPTION
By reordering, moving some stuff to Cow<T>s to reduce the amount of padding in the struct. and preventing the inheritance of initial values.

This change improve the peak RSS of paper-muncher from 547MB to 475MB, a 13% improvement.

Before and after
<img width="1209" height="1202" alt="image" src="https://github.com/user-attachments/assets/19078f8c-4cb7-46ba-9e0a-9f01d6db055a" />
