### PR TITLE
paper-muncher: Remove subcommands and improve configuration of overflow behavior.

### DIFF
--- a/doc/install.md
+++ b/doc/install.md
@@ -14,7 +14,7 @@ cd paper-muncher
 export PATH=$PATH:$HOME/.local/bin
 
 # Render a webpage to PDF
-paper-muncher --unsecure print index.html -o output.pdf
+paper-muncher index.html -o output.pdf
 
 # For more options, run
 paper-muncher --help

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -2,14 +2,9 @@
 
 **Paper-Muncher** is a document rendering tool that converts web documents into high-quality **PDFs** or **rasterized images** using the Vaev layout engine. It supports HTTP and local I/O, and CSS units for layout configuration.
 
-## Commands
-
----
-
-### `print`
 
 ```
-paper-muncher --unsecure print <input> -o <output> [options]
+paper-muncher <input> -o <output> [options]
 ```
 
 Renders a web document to a print-ready file (typically PDF).
@@ -24,47 +19,16 @@ Renders a web document to a print-ready file (typically PDF).
 - `-h,--height <length>`: Override paper height
 - `-f,--format <uti>`: Output format (default: `public.pdf`)
 - `-o,--output <output>`: Output file or URL (default: stdout)
-- `--unsecure`: Allows paper-muncher to access local files and the network. If omitted it will only get access to stdin and stdout.
+- `--sandboxed`: Disallows paper-muncher to access local files and the network.
 - `--timeout <duration>`: Adds a timeout to the document generation, when reached exits with a failure code.
 - `-v,--verbose`: Makes paper-muncher be more talkative, it might yap about how its day's going
 
 **Examples:**
 
 ```sh
-paper-muncher --unsecure print article.html -o out.pdf
-paper-muncher --unsecure print article.html -o out.pdf --paper Letter --orientation landscape
-paper-muncher --unsecure print article.html -o https://example.com/doc.pdf --output-mime application/pdf
-```
-
----
-
-### `render`
-
-```
-paper-muncher --unsecure render <input> -o <output> [options]
-```
-
-Renders a web document to a raster image (BMP, PNG, etc.).
-
-**Options:**
-
-- `--scale <scale>`: CSS resolution (default: `96dpi`)
-- `--density <density>`: Pixel density (default: `96dpi`)
-- `-w,--width <length>`: Viewport width (default: `800px`)
-- `-h,--height <length>`: Viewport height (default: `600px`)
-- `-f,--format <uti>`: Output format (default: `public.bmp`)
-- `--wireframe`: Show wireframe overlay of the layout
-- `-o,--output <output>`: Output file or URL (default: stdout)
-- `--unsecure`: Allows paper-muncher to access local files and the network. If omitted it will only get access to stdin and stdout.
-- `--timeout <duration>`: Adds a timeout to the document generation, when reached exits with a failure code.
-- `-v,--verbose`: Makes paper-muncher be more talkative, it might yap about how its day's going
-
-**Examples:**
-
-```sh
-paper-muncher --unsecure render page.html -o out.bmp
-paper-muncher --unsecure render page.html -o out.png --width 1024px --height 768px --density 192dpi
-paper-muncher --unsecure render page.html -o out.png --wireframe
+paper-muncher article.html -o out.pdf
+paper-muncher article.html -o out.pdf --paper Letter --orientation landscape
+paper-muncher article.html -o https://example.com/doc.pdf --output-mime application/pdf
 ```
 
 *NOTE: `<scale>`, `<density>`, `<orientation>`, `<length>`, `<duration>` all use [CSS unit synthax](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Values_and_Units#units)*

--- a/meta/plugins/reftest.py
+++ b/meta/plugins/reftest.py
@@ -31,11 +31,11 @@ def fetchMessage(args: model.TargetArgs, type: str) -> str:
 
 
 def compareImages(
-        lhs: bytes,
-        rhs: bytes,
-        lowEpsilon: float = 0.05,
-        highEpsilon: float = 0.1,
-        strict=False,
+    lhs: bytes,
+    rhs: bytes,
+    lowEpsilon: float = 0.05,
+    highEpsilon: float = 0.1,
+    strict=False,
 ) -> bool:
     if strict:
         return lhs == rhs
@@ -62,7 +62,10 @@ def compareImages(
 
 
 def runPaperMuncher(executable, type, xsize, ysize, page, outputPath, inputPath):
-    command = ["--feature", "*=on", "--verbose", "--unsecure", type or "render"]
+    command = ["--feature", "*=on", "--verbose"]
+
+    if type == "print":
+        command.extend(["--flow", "paginate"])
 
     if xsize or not page:
         command.extend(["--width", (xsize or 200) + "px"])
@@ -197,7 +200,7 @@ def _(args: RefTestArgs):
                     expected_image_url = ref_image
 
             for tag, info, rendering in re.findall(
-                    r"""<(rendering|error)([^>]*)>([\w\W]+?)</(?:rendering|error)>""", test
+                r"""<(rendering|error)([^>]*)>([\w\W]+?)</(?:rendering|error)>""", test
             ):
                 renderingProps = getInfo(info)
                 test_skipped = category_skipped or "skip" in renderingProps
@@ -222,7 +225,9 @@ def _(args: RefTestArgs):
                     xsize = "800"
                     ysize = "600"
 
-                runPaperMuncher(paperMuncher, type, xsize, ysize, page, img_path, input_path)
+                runPaperMuncher(
+                    paperMuncher, type, xsize, ysize, page, img_path, input_path
+                )
 
                 with img_path.open("rb") as imageFile:
                     output_image: bytes = imageFile.read()
@@ -233,7 +238,7 @@ def _(args: RefTestArgs):
                     if not expected_image:
                         expected_image = output_image
                         with (TEST_REPORT / f"{counter}.expected.bmp").open(
-                                "wb"
+                            "wb"
                         ) as imageWriter:
                             imageWriter.write(expected_image)
                         continue

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ Paper-Muncher is now in early alpha. We're currently focused on improving stabil
 # Basic usage
 
 ```bash
-paper-muncher --unsecure print index.html -o output.pdf
+paper-muncher index.html -o output.pdf
 ```
 
 # Introduction
@@ -62,7 +62,7 @@ cd paper-muncher
 export PATH=$PATH:$HOME/.local/bin
 
 # Render a webpage to PDF
-paper-muncher --unsecure --timeout=10s print index.html -o output.pdf
+paper-muncher index.html -o output.pdf
 
 # For more options, run
 paper-muncher --help

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,356 +1,115 @@
 #include <karm-sys/entry.h>
 
 import Karm.Cli;
-import Karm.Gc;
-import Karm.Http;
-import Karm.Image;
+import PaperMuncher;
 import Karm.Print;
-import Karm.Debug;
-import Karm.Sys;
-import Karm.Gfx;
-import Karm.Math;
 import Karm.Logger;
-import Karm.Scene;
 
 import Vaev.Engine;
 
 using namespace Karm;
 
-template <>
-struct Cli::ValueParser<Print::Margins> {
-    static Res<> usage(Io::TextWriter& w) {
-        return w.writeStr("margin"s);
-    }
-
-    static Res<Print::Margins> parse(Cursor<Token>& c) {
-        if (c.ended() or c->kind != Token::OPERAND)
-            return Error::invalidInput("expected margin");
-
-        auto value = c.next().value;
-
-        if (value == "default")
-            return Ok(Print::Margins::DEFAULT);
-        else if (value == "none")
-            return Ok(Print::Margins::NONE);
-        else if (value == "minimum")
-            return Ok(Print::Margins::MINIMUM);
-        else
-            return Error::invalidInput("expected margin");
-    }
-};
-
-namespace PaperMuncher {
-
-static Rc<Http::Client> _createHttpClient(bool unsecure) {
-    Vec<Rc<Http::Transport>> transports;
-
-    transports.pushBack(Http::pipeTransport());
-
-    if (unsecure) {
-        transports.pushBack(Http::httpTransport());
-        transports.pushBack(Http::localTransport(Http::LocalTransportPolicy::ALLOW_ALL));
-    } else {
-        // NOTE: Only allow access to bundle assets and standard input/output.
-        transports.pushBack(Http::localTransport({"bundle"s, "fd"s, "data"s}));
-    }
-
-    auto client = makeRc<Http::Client>(
-        Http::multiplexTransport(std::move(transports))
-    );
-    client->userAgent = "Paper-Muncher/" stringify$(__ck_version_value) ""s;
-
-    return client;
-}
-
-struct PrintOption {
-    Vaev::Resolution scale = Vaev::Resolution::fromDppx(1);
-    Vaev::Resolution density = Vaev::Resolution::fromDppx(1);
-    Opt<Vaev::Length> width = NONE;
-    Opt<Vaev::Length> height = NONE;
-    Print::PaperStock paper = Print::A4;
-    Print::Orientation orientation = Print::Orientation::PORTRAIT;
-    Print::Margins margins = Print::Margins::DEFAULT;
-    Ref::Uti outputFormat = Ref::Uti::PUBLIC_PDF;
-
-    auto preparePrintSettings(this auto const& self) -> Print::Settings {
-        Vaev::Layout::Resolver resolver;
-        resolver.viewport.dpi = self.scale;
-
-        auto paper = self.paper;
-
-        if (self.orientation == Print::Orientation::LANDSCAPE)
-            paper = paper.landscape();
-
-        if (self.width) {
-            paper.name = "custom";
-            paper.width = resolver.resolve(*self.width).template cast<f64>();
-        }
-
-        if (self.height) {
-            paper.name = "custom";
-            paper.height = resolver.resolve(*self.height).template cast<f64>();
-        }
-
-        return {
-            .paper = paper,
-            .margins = self.margins,
-            .scale = self.scale.toDppx(),
-        };
-    }
-};
-
-static Async::Task<> printAsync(
-    Rc<Http::Client> client,
-    Vec<Ref::Url> const& inputs,
-    Ref::Url const& output,
-    PrintOption options = {}
-) {
-    auto printer = co_try$(
-        Print::FilePrinter::create(
-            options.outputFormat,
-            {
-                .density = options.density.toDppx(),
-            }
-        )
-    );
-
-    for (auto& input : inputs) {
-        logInfo("rendering {}...", input);
-        auto window = Vaev::Dom::Window::create(client);
-        co_trya$(window->loadLocationAsync(input));
-        window->print(options.preparePrintSettings()) | forEach([&](Print::Page& page) {
-            page.print(
-                *printer,
-                {
-                    .showBackgroundGraphics = true,
-                }
-            );
-        });
-    }
-
-    logInfo("saving {}...", output);
-    Io::BufferWriter bw;
-    co_try$(printer->write(bw));
-    co_trya$(client->doAsync(
-        Http::Request::from(
-            Http::Method::PUT,
-            output,
-            Http::Body::from(bw.take())
-        )
-    ));
-
-    co_return Ok();
-}
-
-struct RenderOption {
-    Vaev::Resolution scale = Vaev::Resolution::fromDpi(96);
-    Vaev::Resolution density = Vaev::Resolution::fromDpi(96);
-    Vaev::Length width = 800_au;
-    Vaev::Length height = 600_au;
-    Ref::Uti outputFormat = Ref::Uti::PUBLIC_BMP;
-};
-
-static Async::Task<> renderAsync(
-    Rc<Http::Client> client,
-    Ref::Url const& input,
-    Ref::Url const& output,
-    RenderOption options = {}
-) {
-    auto window = Vaev::Dom::Window::create(client);
-    co_trya$(window->loadLocationAsync(input));
-    Vaev::Layout::Resolver resolver;
-    Vec2Au imageSize = {
-        resolver.resolve(options.width),
-        resolver.resolve(options.height),
-    };
-    window->changeMedia(Vaev::Style::Media::forRender(imageSize.cast<Au>(), options.scale));
-
-    Rc<Http::Body> body = Http::Body::empty();
-
-    Image::Saver saves{.format = options.outputFormat, .density = options.density.toDppx()};
-
-    auto scene = window->render();
-
-    // NOTE: Override the background of HTML document, since no
-    //       one really expect a html document to be transparent
-    if (window->document()->documentElement()->namespaceUri() == Vaev::Html::NAMESPACE) {
-        scene = makeRc<Scene::Clear>(scene, Gfx::WHITE);
-    }
-
-    body = Http::Body::from(co_try$(Image::save(scene, imageSize.cast<isize>(), saves)));
-
-    co_trya$(client->doAsync(
-        Http::Request::from(Http::Method::PUT, output, body)
-    ));
-    co_return Ok();
-}
-
-} // namespace PaperMuncher
-
 Async::Task<> entryPointAsync(Sys::Context& ctx) {
-    auto inputArg = Cli::operand<Str>("input"s, "Input files (default: stdin)"s, "-"s);
+    auto sandboxedArg = Cli::flag(NONE, "sandboxed"s, "Disallow local file and http access"s);
+    auto verboseArg = Cli::flag(NONE, "verbose"s, "Makes paper-muncher be more talkative, it might yap about how its day's going"s);
+    Cli::Section runtimeSection{
+        "Runtime Options"s,
+        {sandboxedArg, verboseArg},
+    };
+
     auto inputsArg = Cli::operand<Vec<Str>>("inputs"s, "Input files (default: stdin)"s, {"-"s});
     auto outputArg = Cli::option<Str>('o', "output"s, "Output file (default: stdout)"s, "-"s);
     auto formatArg = Cli::option<Str>('f', "format"s, "Override the output file format"s, ""s);
-    auto unsecureArg = Cli::flag(NONE, "unsecure"s, "Allow local file and http access"s);
-    auto verboseArg = Cli::flag(NONE, "verbose"s, "Makes paper-muncher be more talkative, it might yap about how its day's going"s);
+    auto densityArg = Cli::option<Str>(NONE, "density"s, "Density of the output document in css units (e.g. 96dpi)"s, "1x"s);
+
+    Cli::Section inOutSection{
+        "Input/Output Options"s,
+        {inputsArg, outputArg, formatArg, densityArg},
+    };
+
+    auto paperArg = Cli::option<Str>(NONE, "paper"s, "Paper size for printing (default: A4)"s, "A4"s);
+    auto orientationArg = Cli::option<Str>(NONE, "orientation"s, "Page orientation (default: portrait)"s, "portrait"s);
+    auto marginArg = Cli::option<Print::Margins::Named>(NONE, "margins"s, "Page margins (default: default)"s, Print::Margins::DEFAULT);
+    Cli::Section paperSection{
+        "Paper Options"s,
+        {paperArg, orientationArg, marginArg},
+    };
+
+    auto widthArg = Cli::option<Str>(NONE, "width"s, "Width of the output document in css units (e.g. 800px)"s, ""s);
+    auto heightArg = Cli::option<Str>(NONE, "height"s, "Height of the output document in css units (e.g. 600px)"s, ""s);
+    auto scaleArg = Cli::option<Str>(NONE, "scale"s, "Scale of the input document in css units (e.g. 1x)"s, "1x"s);
+    auto extendArg = Cli::option<PaperMuncher::Extend>(NONE, "extend"s, "How content extending past the initial viewport is handled (default: crop)"s, PaperMuncher::Extend::CROP);
+    auto flowArg = Cli::option<PaperMuncher::Flow>(NONE, "flow"s, "Flow of the document (default: paginate for PDF, otherwise continuous)"s, PaperMuncher::Flow::AUTO);
+
+    Cli::Section viewportSection{
+        "Viewport Options"s,
+        {widthArg, heightArg, scaleArg, extendArg, flowArg},
+    };
+
+    Cli::Section formatSection{
+        .title = "Supported Formats"s,
+        .prolog =
+            "Input: HTML, XHTML, SVG\n"
+            "Output: PDF or image\n"
+            "Image formats: BMP, PNG, JPEG, TGA, QOI, SVG\n"s
+    };
 
     Cli::Command cmd{
         "paper-muncher"s,
-        "Munch the web into crisp documents"s,
+        "Convert web pages (HTML, XHTML, or SVG) into printable or viewable documents like PDFs or images."s,
         {
-            {
-                "Global Options"s,
-                {
-                    unsecureArg,
-                    verboseArg,
-                },
-            },
-        },
-        [=](Sys::Context&) -> Async::Task<> {
-            setLogLevel(verboseArg.value() ? PRINT : ERROR);
-            if (not unsecureArg.value())
-                co_try$(Sys::enterSandbox());
-            co_return Ok();
+            runtimeSection,
+            inOutSection,
+            paperSection,
+            viewportSection,
+            formatSection,
         }
     };
 
-    auto scaleArg = Cli::option<Str>(NONE, "scale"s, "Scale of the input document in css units (e.g. 1x)"s, "1x"s);
-    auto densityArg = Cli::option<Str>(NONE, "density"s, "Density of the output document in css units (e.g. 96dpi)"s, "1x"s);
-    auto widthArg = Cli::option<Str>(NONE, "width"s, "Width of the output document in css units (e.g. 800px)"s, ""s);
-    auto heightArg = Cli::option<Str>(NONE, "height"s, "Height of the output document in css units (e.g. 600px)"s, ""s);
-    auto paperArg = Cli::option<Str>(NONE, "paper"s, "Paper size for printing (default: A4)"s, "A4"s);
-    auto orientationArg = Cli::option<Str>(NONE, "orientation"s, "Page orientation (default: portrait)"s, "portrait"s);
-    auto marginArg = Cli::option<Print::Margins>(NONE, "margins"s, "Page margins (default: default)"s, Print::Margins::DEFAULT);
+    co_trya$(cmd.execAsync(ctx));
+    if (not cmd)
+        co_return Ok();
 
-    cmd.subCommand(
-        "print"s,
-        "Render a web page into a printable document"s,
-        {
-            {
-                "Input/Output Options"s,
-                {
-                    inputsArg,
-                    outputArg,
-                    formatArg,
-                    densityArg,
-                },
-            },
+    setLogLevel(verboseArg.value() ? PRINT : ERROR);
+    if (sandboxedArg.value())
+        co_try$(Sys::enterSandbox());
 
-            {
-                "Paper Options"s,
-                {
-                    paperArg,
-                    orientationArg,
-                    marginArg,
-                },
-            },
+    PaperMuncher::Option options{};
 
-            {
-                "Viewport Options"s,
-                {
-                    widthArg,
-                    heightArg,
-                    scaleArg,
-                },
-            },
-        },
-        [=](Sys::Context&) -> Async::Task<> {
-            PaperMuncher::PrintOption options{};
+    options.scale = co_try$(Vaev::parseValue<Vaev::Resolution>(scaleArg.value()));
+    options.density = co_try$(Vaev::parseValue<Vaev::Resolution>(densityArg.value()));
 
-            options.scale = co_try$(Vaev::parseValue<Vaev::Resolution>(scaleArg.value()));
-            options.density = co_try$(Vaev::parseValue<Vaev::Resolution>(densityArg.value()));
+    if (widthArg.value())
+        options.width = co_try$(Vaev::parseValue<Vaev::Length>(widthArg.value()));
 
-            if (widthArg.value())
-                options.width = co_try$(Vaev::parseValue<Vaev::Length>(widthArg.value()));
+    if (heightArg.value())
+        options.height = co_try$(Vaev::parseValue<Vaev::Length>(heightArg.value()));
 
-            if (heightArg.value())
-                options.height = co_try$(Vaev::parseValue<Vaev::Length>(heightArg.value()));
+    options.paper = co_try$(Print::findPaperStock(paperArg.value()));
+    options.orientation = co_try$(Vaev::parseValue<Print::Orientation>(orientationArg.value()));
+    options.margins = marginArg.value();
 
-            options.paper = co_try$(Print::findPaperStock(paperArg.value()));
-            options.orientation = co_try$(Vaev::parseValue<Print::Orientation>(orientationArg.value()));
-            options.margins = marginArg.value();
+    Vec<Ref::Url> inputs;
+    for (auto& i : inputsArg.value())
+        if (i == "-"s)
+            inputs.pushBack("fd:stdin"_url);
+        else
+            inputs.pushBack(Ref::parseUrlOrPath(i, co_try$(Sys::pwd())));
 
-            Vec<Ref::Url> inputs;
-            for (auto& i : inputsArg.value())
-                if (i == "-"s)
-                    inputs.pushBack("fd:stdin"_url);
-                else
-                    inputs.pushBack(Ref::parseUrlOrPath(i, co_try$(Sys::pwd())));
+    Ref::Url output = "fd:stdout"_url;
+    if (outputArg.value() != "-"s)
+        output = Ref::parseUrlOrPath(outputArg.value(), co_try$(Sys::pwd()));
 
-            Ref::Url output = "fd:stdout"_url;
-            if (outputArg.value() != "-"s)
-                output = Ref::parseUrlOrPath(outputArg.value(), co_try$(Sys::pwd()));
+    if (formatArg.value() != ""s) {
+        options.outputFormat = co_try$(Ref::Uti::fromMime({formatArg.value()}));
+    } else {
+        auto mime = Ref::sniffSuffix(output.path.suffix());
+        options.outputFormat = mime ? co_try$(Ref::Uti::fromMime(*mime)) : Ref::Uti::PUBLIC_PDF;
+    }
 
-            if (formatArg.value() != ""s) {
-                options.outputFormat = co_try$(Ref::Uti::fromMime({formatArg.value()}));
-            } else {
-                auto mime = Ref::sniffSuffix(output.path.suffix());
-                options.outputFormat = mime ? co_try$(Ref::Uti::fromMime(*mime)) : Ref::Uti::PUBLIC_PDF;
-            }
+    options.flow = flowArg.value();
+    options.extend = extendArg.value();
 
-            auto client = PaperMuncher::_createHttpClient(unsecureArg.value());
-
-            co_return co_await PaperMuncher::printAsync(client, inputs, output, options);
-        }
-    );
-
-    cmd.subCommand(
-        "render"s,
-        "Render a web page into an image"s,
-        {
-            {
-                "Input/Output Options"s,
-                {
-                    inputArg,
-                    outputArg,
-                    formatArg,
-                    densityArg,
-                },
-            },
-
-            {
-                "Viewport Options"s,
-                {
-
-                    widthArg,
-                    heightArg,
-                    scaleArg,
-                },
-            },
-        },
-        [=](Sys::Context&) -> Async::Task<> {
-            PaperMuncher::RenderOption options{};
-
-            options.scale = co_try$(Vaev::parseValue<Vaev::Resolution>(scaleArg.value()));
-            options.density = co_try$(Vaev::parseValue<Vaev::Resolution>(densityArg.value()));
-
-            if (widthArg.value())
-                options.width = co_try$(Vaev::parseValue<Vaev::Length>(widthArg.value()));
-
-            if (heightArg.value())
-                options.height = co_try$(Vaev::parseValue<Vaev::Length>(heightArg.value()));
-
-            Ref::Url input = "fd:stdin"_url;
-            if (inputArg.value() != "-"s)
-                input = Ref::parseUrlOrPath(inputArg.value(), co_try$(Sys::pwd()));
-
-            Ref::Url output = "fd:stdout"_url;
-            if (outputArg.value() != "-"s)
-                output = Ref::parseUrlOrPath(outputArg.value(), co_try$(Sys::pwd()));
-
-            if (formatArg.value() != ""s) {
-                options.outputFormat = co_try$(Ref::Uti::fromMime({formatArg.value()}));
-            } else {
-                auto mime = Ref::sniffSuffix(output.path.suffix());
-                options.outputFormat = mime ? co_try$(Ref::Uti::fromMime(*mime)) : Ref::Uti::PUBLIC_BMP;
-            }
-
-            auto client = PaperMuncher::_createHttpClient(unsecureArg.value());
-
-            co_return co_await renderAsync(client, input, output, options);
-        }
-    );
-
-    co_return co_await cmd.execAsync(ctx);
+    auto client = PaperMuncher::defaultHttpClient(sandboxedArg.value());
+    co_return co_await PaperMuncher::run(client, inputs, output, options);
 }

--- a/src/mod.cpp
+++ b/src/mod.cpp
@@ -1,0 +1,186 @@
+module;
+
+#include <karm-core/macros.h>
+
+export module PaperMuncher;
+
+import Karm.Gc;
+import Karm.Http;
+import Karm.Image;
+import Karm.Print;
+import Karm.Debug;
+import Karm.Sys;
+import Karm.Gfx;
+import Karm.Math;
+import Karm.Logger;
+import Karm.Scene;
+import Karm.Core;
+import Karm.Ref;
+
+import Vaev.Engine;
+
+using namespace Karm;
+
+namespace PaperMuncher {
+
+export enum struct Flow {
+    AUTO,
+    PAGINATE,
+    CONTINUOUS,
+    _LEN,
+};
+
+export enum struct Extend {
+    CROP, //< The document is cropped to the container
+    FIT,  //< Container is resized to fit the document
+    _LEN,
+};
+
+export Rc<Http::Client> defaultHttpClient(bool sandboxed) {
+    Vec<Rc<Http::Transport>> transports;
+
+    transports.pushBack(Http::pipeTransport());
+
+    if (sandboxed) {
+        // NOTE: Only allow access to bundle assets and standard input/output.
+        transports.pushBack(Http::localTransport({"bundle"s, "fd"s, "data"s}));
+    } else {
+        transports.pushBack(Http::httpTransport());
+        transports.pushBack(Http::localTransport(Http::LocalTransportPolicy::ALLOW_ALL));
+    }
+
+    auto client = makeRc<Http::Client>(
+        Http::multiplexTransport(std::move(transports))
+    );
+    client->userAgent = "Paper-Muncher/" stringify$(__ck_version_value) ""s;
+
+    return client;
+}
+
+export struct Option {
+    Vaev::Resolution scale = Vaev::Resolution::fromDppx(1);
+    Vaev::Resolution density = Vaev::Resolution::fromDppx(1);
+    Opt<Vaev::Length> width = NONE;
+    Opt<Vaev::Length> height = NONE;
+    Print::PaperStock paper = Print::A4;
+    Print::Orientation orientation = Print::Orientation::PORTRAIT;
+    Print::Margins margins = Print::Margins::DEFAULT;
+    Ref::Uti outputFormat = Ref::Uti::PUBLIC_DATA;
+    Flow flow = Flow::AUTO;
+    Extend extend = Extend::CROP;
+
+    auto preparePrintSettings() -> Print::Settings {
+        Vaev::Layout::Resolver resolver;
+        resolver.viewport.dpi = this->scale;
+
+        auto paper = this->paper;
+
+        if (this->orientation == Print::Orientation::LANDSCAPE)
+            paper = paper.landscape();
+
+        if (this->width or this->height) {
+            paper.name = "custom";
+            if (this->width)
+                paper.width = resolver.resolve(*this->width).cast<f64>();
+
+            if (this->height)
+                paper.height = resolver.resolve(*this->height).cast<f64>();
+        }
+
+        return {
+            .paper = paper,
+            .margins = this->margins,
+            .scale = this->scale.toDppx(),
+        };
+    }
+
+    Vaev::Style::Media prepareMedia() {
+        Vaev::Layout::Resolver resolver;
+        auto width = this->width ? resolver.resolve(*this->width) : 800_au;
+        auto height = this->height ? resolver.resolve(*this->height) : 600_au;
+        return Vaev::Style::Media::forRender({width, height}, this->scale);
+    }
+};
+
+export Async::Task<> run(
+    Rc<Http::Client> client,
+    Vec<Ref::Url> const& inputs,
+    Ref::Url const& output,
+    Option options = {}
+) {
+    if (options.flow == Flow::AUTO)
+        options.flow =
+            options.outputFormat == Ref::Uti::PUBLIC_PDF
+                ? Flow::PAGINATE
+                : Flow::CONTINUOUS;
+
+    auto printer = co_try$(
+        Print::FilePrinter::create(
+            options.outputFormat,
+            {
+                .density = options.density.toDppx(),
+            }
+        )
+    );
+
+    for (auto& input : inputs) {
+        logInfo("loading {}...", input);
+        auto window = Vaev::Dom::Window::create(client);
+        co_trya$(window->loadLocationAsync(input));
+
+        logInfo("rendering {}...", input);
+        if (options.flow == Flow::PAGINATE) {
+            auto settings = options.preparePrintSettings();
+            window->print(settings) | forEach([&](Print::Page& page) {
+                page.print(
+                    *printer,
+                    {.showBackgroundGraphics = true}
+                );
+            });
+        } else {
+            auto media = options.prepareMedia();
+            window->changeMedia(media);
+
+            auto scene = window->render();
+
+            // NOTE: Override the background of HTML document, since no
+            //       one really expect a html document to be transparent
+            if (window->document()->documentElement()->namespaceUri() == Vaev::Html::NAMESPACE) {
+                scene = makeRc<Scene::Clear>(scene, Gfx::WHITE);
+            }
+
+            Print::PaperStock paper{
+                "image",
+                media.width.cast<f64>(),
+                media.height.cast<f64>(),
+            };
+
+            if (options.extend == Extend::FIT) {
+                auto overflow = window->ensureRender().frag->scrollableOverflow();
+                paper.width = overflow.width.cast<f64>();
+                paper.height = overflow.height.cast<f64>();
+            }
+
+            Print::Page page = {paper, scene};
+            page.print(
+                *printer,
+                {.showBackgroundGraphics = true}
+            );
+        }
+    }
+
+    logInfo("saving {}...", output);
+    Io::BufferWriter bw;
+    co_try$(printer->write(bw));
+    co_trya$(client->doAsync(
+        Http::Request::from(
+            Http::Method::PUT,
+            output,
+            Http::Body::from(bw.take())
+        )
+    ));
+
+    co_return Ok();
+}
+
+} // namespace PaperMuncher


### PR DESCRIPTION
This PR focuses on making Paper Muncher easier to use for first-time users and adds more flexible overflow handling. The CLI no longer requires subcommands, and new overflow modes make it possible to generate continuous single-page PDFs.

# Simplified CLI

You can now just run:
```
paper-muncher index.html -o output.pdf
```

# Why --overflow

The parameter name comes from CSS’s own overflow property, which defines how content that exceeds its container is handled. Paper Muncher now exposes the same concept at the document level, deciding what happens when rendered content exceeds the page boundaries.

paginate - split content into multiple pages
crop - crop content to the page size
visible - render only visible content
auto - automatically choose based on output format