### PR TITLE
vaev-html: Improve foster parenting.

### DIFF
--- a/src/vaev-engine/dom/tree.cpp
+++ b/src/vaev-engine/dom/tree.cpp
@@ -92,11 +92,11 @@ struct Tree : Meta::Pinned {
             _lastChild = _firstChild;
     }
 
-    void insertBefore(Node* node, Node* child) {
+    void insertBefore(Gc::Ptr<Node> node, Gc::Ptr<Node> child) {
         if (!child)
             return appendChild(node);
 
-        if (child->_parent != this)
+        if (child->_parent != Gc::Ptr<Node>{MOVE, static_cast<Node*>(this)})
             panic("node is not a child");
 
         if (node->_parent)
@@ -113,11 +113,11 @@ struct Tree : Meta::Pinned {
 
         child->_prevSibling = node;
 
-        node->_parent = static_cast<Node*>(this);
+        node->_parent = {MOVE, static_cast<Node*>(this)};
     }
 
-    void insertAfter(Node* node, Node* child) {
-        if (child->_parent != this)
+    void insertAfter(Gc::Ptr<Node> node, Gc::Ptr<Node> child) {
+        if (child->_parent != Gc::Ptr<Node>{MOVE, static_cast<Node*>(this)})
             panic("node is not a child");
 
         if (node->_parent)
@@ -134,10 +134,10 @@ struct Tree : Meta::Pinned {
 
         child->_nextSibling = node;
 
-        node->_parent = static_cast<Node*>(this);
+        node->_parent = {MOVE, static_cast<Node*>(this)};
     }
 
-    void removeChild(Node* node) {
+    void removeChild(Gc::Ptr<Node> node) {
         if (node->_parent != this)
             panic("node is not a child");
 

--- a/src/vaev-engine/html/tests/test-html-parser.cpp
+++ b/src/vaev-engine/html/tests/test-html-parser.cpp
@@ -515,4 +515,26 @@ test$("parse-svg-case-fix") {
     return Ok();
 }
 
+test$("parse-misnested-content-in-table") {
+    Gc::Heap gc;
+    auto dom = gc.alloc<Dom::Document>(Ref::Url());
+    Html::HtmlParser parser{gc, dom};
+
+    parser.write("<table><div>fostered</div><tr><td>cell</td></tr></table>");
+
+    auto html = dom->firstChild()->is<Element>();
+    auto body = html->lastChild()->is<Element>();
+
+    auto fostered = body->firstChild()->is<Element>();
+    expectNe$(fostered, nullptr);
+    expect$(fostered->qualifiedName == Html::DIV_TAG);
+
+    auto table = fostered->nextSibling()->is<Element>();
+    expectNe$(table, nullptr);
+    expect$(table->qualifiedName == Html::TABLE_TAG);
+
+    return Ok();
+}
+
+
 } // namespace Vaev::Dom::Tests


### PR DESCRIPTION
Hoist unsupported elements in certain contexts, such as a `<div>` inside a `<table>`.
