### PR TITLE
vaev-engine: Assign FONT computation phase to font-* props.

### DIFF
--- a/src/vaev-engine/props/fonts.cpp
+++ b/src/vaev-engine/props/fonts.cpp
@@ -26,6 +26,10 @@ export struct FontFamilyProperty : Property {
             return {INHERITED};
         }
 
+        ComputationPhase computationPhase() const override {
+            return ComputationPhase::FONT;
+        }
+
         Rc<Property> initial() const override {
             return makeRc<FontFamilyProperty>(self(), Vec<FontFamily>{"sans-serif"_sym});
         }
@@ -73,8 +77,20 @@ export struct FontWeightProperty : Property {
             return Properties::FONT_WEIGHT;
         }
 
+        Flags<Options> flags() const override {
+            return {INHERITED};
+        }
+
+        ComputationPhase computationPhase() const override {
+            return ComputationPhase::FONT;
+        }
+
         Rc<Property> initial() const override {
             return makeRc<FontWeightProperty>(self(), FontWeight{Gfx::FontWeight::REGULAR});
+        }
+
+        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
+            child.font.cow().weight = parent.font->weight;
         }
 
         Rc<Property> load(ComputedValues const& c) const override {
@@ -120,6 +136,10 @@ export struct FontWidthProperty : Property {
             return {INHERITED};
         }
 
+        ComputationPhase computationPhase() const override {
+            return ComputationPhase::FONT;
+        }
+
         Rc<Property> initial() const override {
             return makeRc<FontWidthProperty>(self(), FontWidth::NORMAL);
         }
@@ -162,6 +182,10 @@ export struct FontStyleProperty : Property {
             return {INHERITED};
         }
 
+        ComputationPhase computationPhase() const override {
+            return ComputationPhase::FONT;
+        }
+
         Rc<Property> initial() const override {
             return makeRc<FontStyleProperty>(self(), FontStyle::NORMAL);
         }
@@ -202,6 +226,10 @@ export struct FontSizeProperty : Property {
 
         Flags<Options> flags() const override {
             return {INHERITED};
+        }
+
+        ComputationPhase computationPhase() const override {
+            return ComputationPhase::FONT;
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/style/computer.cpp
+++ b/src/vaev-engine/style/computer.cpp
@@ -48,6 +48,7 @@ export struct Computer {
     Rc<Gfx::Fontface> _lookupFontface(ComputedValues& style) {
         Font::Query fq{
             .weight = style.font->weight,
+            .stretch = Gfx::FontStretch{static_cast<u16>(Math::roundi(style.font->width.val().value() * 10.0))},
             .style = style.font->style.val,
         };
 
@@ -216,9 +217,12 @@ export struct Computer {
         cascadedValues.apply(Property::ComputationPhase::PRE_FONT, parent, *values);
         cascadedValues.apply(Property::ComputationPhase::FONT, parent, *values);
 
+        // FIXME: Use a font-dirty flag instead.
         if (not parent.font.sameInstance(values->font) and
             (parent.font->families != values->font->families or
-             parent.font->weight != values->font->weight)) {
+             parent.font->weight != values->font->weight or
+             parent.font->style != values->font->style or
+             parent.font->width != values->font->width)) {
             auto font = _lookupFontface(*values);
             values->fontFace = font;
         } else {
@@ -249,9 +253,12 @@ export struct Computer {
         cascadedValues.apply(Property::ComputationPhase::PRE_FONT, parent, *values);
         cascadedValues.apply(Property::ComputationPhase::FONT, parent, *values);
 
+        // FIXME: Use a font-dirty flag instead.
         if (not parent.font.sameInstance(values->font) and
             (parent.font->families != values->font->families or
-             parent.font->weight != values->font->weight)) {
+             parent.font->weight != values->font->weight or
+             parent.font->style != values->font->style or
+             parent.font->width != values->font->width)) {
             auto font = _lookupFontface(*values);
             values->fontFace = font;
         } else {

--- a/tests/css/cascade/font.xhtml
+++ b/tests/css/cascade/font.xhtml
@@ -1,0 +1,158 @@
+<test id="cascade-font-family" name="cascade: font-family">
+    <container>
+        <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+        <body>
+        <slot />
+        </body>
+
+        </html>
+    </container>
+
+    <rendering>
+        <div style="font-family: serif">
+            Foo Bar
+        </div>
+    </rendering>
+
+    <rendering>
+        <div style="font-family: serif; display: contents">
+            <div>
+                Foo Bar
+            </div>
+        </div>
+    </rendering>
+
+    <error>
+        <div>
+            Foo Bar
+        </div>
+    </error>
+</test>
+
+<test id="cascade-font-weight" name="cascade: font-weight">
+    <container>
+        <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+        <body>
+        <slot />
+        </body>
+
+        </html>
+    </container>
+
+    <rendering>
+        <div style="font-weight: bold;">
+            Foo Bar
+        </div>
+    </rendering>
+
+    <rendering>
+        <div style="font-weight: bold; display: contents">
+            <div>
+                Foo Bar
+            </div>
+        </div>
+    </rendering>
+
+    <error>
+        <div>
+            Foo Bar
+        </div>
+    </error>
+</test>
+
+<test id="cascade-font-width" name="cascade: font-width">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+    <body>
+    <slot />
+    </body>
+
+    </html>
+</container>
+
+<rendering>
+    <div style="font-width: 50%">
+        Foo Bar
+    </div>
+</rendering>
+
+<rendering>
+    <div style="font-width: 50%; display: contents">
+        <div>
+            Foo Bar
+        </div>
+    </div>
+</rendering>
+
+<!--No error case for now because we don't implement synthesized font width.-->
+
+</test>
+
+<test id="cascade-font-style" name="cascade: font-style">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+    <body>
+    <slot />
+    </body>
+
+    </html>
+</container>
+
+<rendering>
+    <div style="font-style: italic">
+        Foo Bar
+    </div>
+</rendering>
+
+<rendering>
+    <div style="font-style: italic; display: contents">
+        <div>
+            Foo Bar
+        </div>
+    </div>
+</rendering>
+
+<error>
+    <div>
+        Foo Bar
+    </div>
+</error>
+
+</test>
+
+<test id="cascade-font-size" name="cascade: font-size">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+    <body>
+    <slot />
+    </body>
+
+    </html>
+</container>
+
+<rendering>
+    <div style="font-size: large">
+        Foo Bar
+    </div>
+</rendering>
+
+<rendering>
+    <div style="font-size: large; display: contents">
+        <div>
+            Foo Bar
+        </div>
+    </div>
+</rendering>
+
+<error>
+    <div>
+        Foo Bar
+    </div>
+</error>
+
+</test>


### PR DESCRIPTION
This is necessary to make the font-face compute correctly.