### PR TITLE
vaev-style: Nuke single argument apply().

### DIFF
--- a/src/vaev-engine/props/align.cpp
+++ b/src/vaev-engine/props/align.cpp
@@ -41,7 +41,7 @@ export struct AlignContentProperty : Property {
     AlignContentProperty(Rc<Property::Registration> registration, Align value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.aligns.alignContent = _value;
     }
 
@@ -75,7 +75,7 @@ export struct JustifyContentProperty : Property {
     JustifyContentProperty(Rc<Property::Registration> registration, Align value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.aligns.justifyContent = _value;
     }
 
@@ -109,7 +109,7 @@ export struct JustifySelfProperty : Property {
     JustifySelfProperty(Rc<Property::Registration> registration, Align value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.aligns.justifySelf = _value;
     }
 
@@ -143,7 +143,7 @@ export struct AlignSelfProperty : Property {
     AlignSelfProperty(Rc<Property::Registration> registration, Align value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.aligns.alignSelf = _value;
     }
 
@@ -177,7 +177,7 @@ export struct JustifyItemsProperty : Property {
     JustifyItemsProperty(Rc<Property::Registration> registration, Align value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.aligns.justifyItems = _value;
     }
 
@@ -211,7 +211,7 @@ export struct AlignItemsProperty : Property {
     AlignItemsProperty(Rc<Property::Registration> registration, Align value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.aligns.alignItems = _value;
     }
 
@@ -250,7 +250,7 @@ export struct RowGapProperty : Property {
     RowGapProperty(Rc<Property::Registration> registration, Gap value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.gaps.cow().row = _value;
     }
 
@@ -289,7 +289,7 @@ export struct ColumnGapProperty : Property {
     ColumnGapProperty(Rc<Property::Registration> registration, Gap value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.gaps.cow().col = _value;
     }
 

--- a/src/vaev-engine/props/background.cpp
+++ b/src/vaev-engine/props/background.cpp
@@ -43,7 +43,7 @@ export struct BackgroundColorProperty : Property {
     BackgroundColorProperty(Rc<Property::Registration> registration, Color value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.backgrounds.cow().color = _value;
     }
 
@@ -89,7 +89,7 @@ export struct BackgroundAttachmentProperty : Property {
     BackgroundAttachmentProperty(Rc<Property::Registration> registration, Vec<BackgroundAttachment> value)
         : Property(registration), _value(std::move(value)) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         auto& layers = c.backgrounds.cow().layers;
         layers.resize(max(layers.len(), _value.len()));
         for (usize i = 0; i < _value.len(); ++i)
@@ -127,7 +127,7 @@ export struct BackgroundImageProperty : Property {
     BackgroundImageProperty(Rc<Property::Registration> registration, Vec<Image> value)
         : Property(registration), _value(std::move(value)) {}
 
-    void apply(ComputedValues&) const override {
+    void apply(ComputedValues const&, ComputedValues&) const override {
         // TODO
     }
 
@@ -162,9 +162,10 @@ export struct BackgroundPositionProperty : Property {
     BackgroundPositionProperty(Rc<Property::Registration> registration, Vec<BackgroundPosition> value)
         : Property(registration), _value(std::move(value)) {}
 
-    void apply(ComputedValues&) const override {
+    void apply(ComputedValues const&, ComputedValues&) const override {
         // TODO
     }
+
 
     void repr(Io::Emit& e) const override {
         e("{}", _value);
@@ -198,7 +199,7 @@ export struct BackgroundRepeatProperty : Property {
         : Property(registration),
           _value(std::move(value)) {}
 
-    void apply(ComputedValues&) const override {
+    void apply(ComputedValues const&, ComputedValues&) const override {
         // TODO
     }
 

--- a/src/vaev-engine/props/base.cpp
+++ b/src/vaev-engine/props/base.cpp
@@ -118,7 +118,7 @@ export struct Property : Meta::NoCopy {
             //       flag should override this method with a faster implementation.
             if (flags().has(INHERITED))
                 logFatal("property {#} marked as INHERITED is using the slow fallback path. override inherit()!", name());
-            load(parent)->apply(child);
+            load(parent)->apply(parent, child);
         }
 
         virtual Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const = 0;
@@ -152,13 +152,8 @@ export struct Property : Meta::NoCopy {
         return {};
     }
 
-    virtual void apply(ComputedValues&) const {
+    virtual void apply([[maybe_unused]] ComputedValues const& parent, [[maybe_unused]] ComputedValues& child) const {
         logFatal("longhand property {#} is missing apply() implementation", registration->name());
-    }
-
-    virtual void apply(ComputedValues const& parent, ComputedValues& child) const {
-        (void)parent;
-        apply(child);
     }
 
     virtual void repr(Io::Emit& e) const = 0;
@@ -251,8 +246,8 @@ struct CustomProperty : Property {
     CustomProperty(Rc<Property::Registration> registration, Css::Content value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& child) const override {
-        child.setCustomProp(registration->name(), _value);
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
+        c.setCustomProp(registration->name(), _value);
     }
 
     void repr(Io::Emit& e) const override {
@@ -471,13 +466,13 @@ struct DefaultedProperty : Property {
             // The inherit CSS-wide keyword represents the property’s
             // computed value on the parent element.
             // https://drafts.csswg.org/css-cascade/#inherit
-            registration->load(parent)->apply(child);
+            registration->load(parent)->apply(parent, child);
         } else if (_value == Default::UNSET) {
             // The unset CSS-wide keyword acts as either inherit or initial,
             // depending on whether the property is inherited or not.
             // https://drafts.csswg.org/css-cascade/#inherit-initial
             if (registration->flags().has(INHERITED))
-                registration->load(parent)->apply(child);
+                registration->load(parent)->apply(parent, child);
             else
                 registration->initial()->apply(parent, child);
 

--- a/src/vaev-engine/props/baseline.cpp
+++ b/src/vaev-engine/props/baseline.cpp
@@ -48,7 +48,7 @@ export struct LineHeightProperty : Property {
     LineHeightProperty(Rc<Property::Registration> registration, LineHeight value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues&) const override {
+    void apply(ComputedValues const&, ComputedValues&) const override {
         // TODO
     }
 
@@ -82,7 +82,7 @@ export struct DominantBaselineProperty : Property {
     DominantBaselineProperty(Rc<Property::Registration> registration, DominantBaseline value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.baseline.cow().dominant = _value;
     }
 
@@ -116,7 +116,7 @@ export struct BaselineSourceProperty : Property {
     BaselineSourceProperty(Rc<Property::Registration> registration, BaselineSource value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.baseline.cow().source = _value;
     }
 
@@ -150,7 +150,7 @@ export struct AlignmentBaselineProperty : Property {
     AlignmentBaselineProperty(Rc<Property::Registration> registration, AlignmentBaseline value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.baseline.cow().alignment = _value;
     }
 

--- a/src/vaev-engine/props/border.cpp
+++ b/src/vaev-engine/props/border.cpp
@@ -40,7 +40,7 @@ export struct BorderTopColorProperty : Property {
     BorderTopColorProperty(Rc<Property::Registration> registration, Color value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().top.color = _value;
     }
 
@@ -74,7 +74,7 @@ export struct BorderRightColorProperty : Property {
     BorderRightColorProperty(Rc<Property::Registration> registration, Color value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().end.color = _value;
     }
 
@@ -108,7 +108,7 @@ export struct BorderBottomColorProperty : Property {
     BorderBottomColorProperty(Rc<Property::Registration> registration, Color value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().bottom.color = _value;
     }
 
@@ -142,7 +142,7 @@ export struct BorderLeftColorProperty : Property {
     BorderLeftColorProperty(Rc<Property::Registration> registration, Color value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().start.color = _value;
     }
 
@@ -227,7 +227,7 @@ export struct BorderLeftStyleProperty : Property {
     BorderLeftStyleProperty(Rc<Property::Registration> registration, Gfx::BorderStyle value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().start.style = _value;
     }
 
@@ -261,7 +261,7 @@ export struct BorderTopStyleProperty : Property {
     BorderTopStyleProperty(Rc<Property::Registration> registration, Gfx::BorderStyle value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().top.style = _value;
     }
 
@@ -295,7 +295,7 @@ export struct BorderRightStyleProperty : Property {
     BorderRightStyleProperty(Rc<Property::Registration> registration, Gfx::BorderStyle value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().end.style = _value;
     }
 
@@ -329,7 +329,7 @@ export struct BorderBottomStyleProperty : Property {
     BorderBottomStyleProperty(Rc<Property::Registration> registration, Gfx::BorderStyle value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().bottom.style = _value;
     }
 
@@ -415,7 +415,7 @@ export struct BorderTopWidthProperty : Property {
     BorderTopWidthProperty(Rc<Property::Registration> registration, LineWidth value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().top.width = _value;
     }
 
@@ -449,7 +449,7 @@ export struct BorderRightWidthProperty : Property {
     BorderRightWidthProperty(Rc<Property::Registration> registration, LineWidth value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().end.width = _value;
     }
 
@@ -483,7 +483,7 @@ export struct BorderBottomWidthProperty : Property {
     BorderBottomWidthProperty(Rc<Property::Registration> registration, LineWidth value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().bottom.width = _value;
     }
 
@@ -517,7 +517,7 @@ export struct BorderLeftWidthProperty : Property {
     BorderLeftWidthProperty(Rc<Property::Registration> registration, LineWidth value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().start.width = _value;
     }
 
@@ -558,7 +558,7 @@ export struct BorderRadiusTopRightProperty : Property {
     BorderRadiusTopRightProperty(Rc<Property::Registration> registration, Array<CalcValue<PercentOr<Length>>, 2> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().radii.c = _value[0];
         c.borders.cow().radii.d = _value[1];
     }
@@ -603,7 +603,7 @@ export struct BorderRadiusTopLeftProperty : Property {
     BorderRadiusTopLeftProperty(Rc<Property::Registration> registration, Array<CalcValue<PercentOr<Length>>, 2> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().radii.a = _value[1];
         c.borders.cow().radii.b = _value[0];
     }
@@ -645,7 +645,7 @@ export struct BorderRadiusBottomRightProperty : Property {
     BorderRadiusBottomRightProperty(Rc<Property::Registration> registration, Array<CalcValue<PercentOr<Length>>, 2> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().radii.e = _value[1];
         c.borders.cow().radii.f = _value[0];
     }
@@ -690,7 +690,7 @@ export struct BorderRadiusBottomLeftProperty : Property {
     BorderRadiusBottomLeftProperty(Rc<Property::Registration> registration, Array<CalcValue<PercentOr<Length>>, 2> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().radii.g = _value[0];
         c.borders.cow().radii.h = _value[1];
     }
@@ -725,7 +725,7 @@ export struct BorderRadiusProperty : Property {
     BorderRadiusProperty(Rc<Property::Registration> registration, Math::Radii<CalcValue<PercentOr<Length>>> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.borders.cow().radii = _value;
     }
 
@@ -1064,7 +1064,7 @@ export struct BorderCollapseProperty : Property {
     BorderCollapseProperty(Rc<Property::Registration> registration, BorderCollapse value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.table.cow().collapse = _value;
     }
 
@@ -1106,7 +1106,7 @@ export struct BorderSpacingProperty : Property {
     BorderSpacingProperty(Rc<Property::Registration> registration, BorderSpacing value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.table.cow().spacing = _value;
     }
 

--- a/src/vaev-engine/props/breaks.cpp
+++ b/src/vaev-engine/props/breaks.cpp
@@ -40,7 +40,7 @@ export struct BreakAfterProperty : Property {
     BreakAfterProperty(Rc<Property::Registration> registration, BreakBetween value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.break_.cow().after = _value;
     }
 
@@ -74,7 +74,7 @@ export struct BreakBeforeProperty : Property {
     BreakBeforeProperty(Rc<Property::Registration> registration, BreakBetween value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.break_.cow().before = _value;
     }
 
@@ -108,7 +108,7 @@ export struct BreakInsideProperty : Property {
     BreakInsideProperty(Rc<Property::Registration> registration, BreakInside value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.break_.cow().inside = _value;
     }
 

--- a/src/vaev-engine/props/display.cpp
+++ b/src/vaev-engine/props/display.cpp
@@ -38,8 +38,8 @@ export struct DisplayProperty : Property {
     DisplayProperty(Rc<Property::Registration> registration, Display value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& s) const override {
-        s.display = _value;
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
+        c.display = _value;
     }
 
     void repr(Io::Emit& e) const override {
@@ -73,7 +73,7 @@ export struct ContentProperty : Property {
     ContentProperty(Rc<Property::Registration> registration, Content value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.content = _value;
     }
 
@@ -107,7 +107,7 @@ export struct OrderProperty : Property {
     OrderProperty(Rc<Property::Registration> registration, Integer value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.order = _value;
     }
 

--- a/src/vaev-engine/props/flex.cpp
+++ b/src/vaev-engine/props/flex.cpp
@@ -40,7 +40,7 @@ export struct FlexBasisProperty : Property {
     FlexBasisProperty(Rc<Property::Registration> registration, FlexBasis value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.flex.cow().basis = _value;
     }
 
@@ -74,7 +74,7 @@ export struct FlexDirectionProperty : Property {
     FlexDirectionProperty(Rc<Property::Registration> registration, FlexDirection value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.flex.cow().direction = _value;
     }
 
@@ -108,7 +108,7 @@ export struct FlexGrowProperty : Property {
     FlexGrowProperty(Rc<Property::Registration> registration, Number value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.flex.cow().grow = _value;
     }
 
@@ -142,7 +142,7 @@ export struct FlexShrinkProperty : Property {
     FlexShrinkProperty(Rc<Property::Registration> registration, Number value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.flex.cow().shrink = _value;
     }
 
@@ -176,7 +176,7 @@ export struct FlexWrapProperty : Property {
     FlexWrapProperty(Rc<Property::Registration> registration, FlexWrap value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.flex.cow().wrap = _value;
     }
 

--- a/src/vaev-engine/props/floats.cpp
+++ b/src/vaev-engine/props/floats.cpp
@@ -39,7 +39,7 @@ export struct FloatProperty : Property {
     FloatProperty(Rc<Property::Registration> registration, Float value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.float_ = _value;
     }
 
@@ -72,7 +72,7 @@ export struct ClearProperty : Property {
     ClearProperty(Rc<Property::Registration> registration, Clear value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.clear = _value;
     }
 

--- a/src/vaev-engine/props/fonts.cpp
+++ b/src/vaev-engine/props/fonts.cpp
@@ -61,7 +61,7 @@ export struct FontFamilyProperty : Property {
     FontFamilyProperty(Rc<Property::Registration> registration, Vec<FontFamily> value)
         : Property(registration), _value(std::move(value)) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.font.cow().families = _value;
     }
 
@@ -106,10 +106,6 @@ export struct FontWeightProperty : Property {
 
     FontWeightProperty(Rc<Property::Registration> registration, FontWeight value)
         : Property(registration), _value(value) {}
-
-    void apply(ComputedValues& c) const override {
-        c.font.cow().weight = _value.resolve();
-    }
 
     void apply(ComputedValues const& parent, ComputedValues& c) const override {
         c.font.cow().weight = _value.resolve(parent.font->weight);
@@ -162,7 +158,7 @@ export struct FontWidthProperty : Property {
     FontWidthProperty(Rc<Property::Registration> registration, FontWidth value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.font.cow().width = _value;
     }
 
@@ -208,7 +204,7 @@ export struct FontStyleProperty : Property {
     FontStyleProperty(Rc<Property::Registration> registration, FontStyle value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.font.cow().style = _value;
     }
 
@@ -254,7 +250,7 @@ export struct FontSizeProperty : Property {
     FontSizeProperty(Rc<Property::Registration> registration, FontSize value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.font.cow().size = _value;
     }
 

--- a/src/vaev-engine/props/margin.cpp
+++ b/src/vaev-engine/props/margin.cpp
@@ -41,7 +41,7 @@ export struct MarginTopProperty : Property {
     MarginTopProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.margin.cow().top = _value;
     }
 
@@ -74,7 +74,7 @@ export struct MarginRightProperty : Property {
     MarginRightProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.margin.cow().end = _value;
     }
 
@@ -107,7 +107,7 @@ export struct MarginBottomProperty : Property {
     MarginBottomProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.margin.cow().bottom = _value;
     }
 
@@ -140,7 +140,7 @@ export struct MarginLeftProperty : Property {
     MarginLeftProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.margin.cow().start = _value;
     }
 
@@ -217,7 +217,7 @@ export struct MarginInlineStartProperty : Property {
     MarginInlineStartProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         // FIXME: Take writing mode into account
         c.margin.cow().start = _value;
     }
@@ -251,7 +251,7 @@ export struct MarginInlineEndProperty : Property {
     MarginInlineEndProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         // FIXME: Take writing mode into account
         c.margin.cow().end = _value;
     }
@@ -285,7 +285,7 @@ export struct MarginInlineProperty : Property {
     MarginInlineProperty(Rc<Property::Registration> registration, Math::Insets<Width> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         // FIXME: Take writing mode into account
         c.margin.cow().start = _value.start;
         c.margin.cow().end = _value.end;
@@ -320,7 +320,7 @@ export struct MarginBlockStartProperty : Property {
     MarginBlockStartProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         // FIXME: Take writing mode into account
         c.margin.cow().top = _value;
     }
@@ -354,7 +354,7 @@ export struct MarginBlockEndProperty : Property {
     MarginBlockEndProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         // FIXME: Take writing mode into account
         c.margin.cow().bottom = _value;
     }
@@ -388,7 +388,7 @@ export struct MarginBlockProperty : Property {
     MarginBlockProperty(Rc<Property::Registration> registration, Math::Insets<Width> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         // FIXME: Take writing mode into account
         c.margin.cow().top = _value.top;
         c.margin.cow().bottom = _value.bottom;

--- a/src/vaev-engine/props/outline.cpp
+++ b/src/vaev-engine/props/outline.cpp
@@ -40,7 +40,7 @@ export struct OutlineWidthProperty : Property {
     OutlineWidthProperty(Rc<Property::Registration> registration, LineWidth value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.outline.cow().width = _value;
     }
 
@@ -76,7 +76,7 @@ export struct OutlineStyleProperty : Property {
     OutlineStyleProperty(Rc<Property::Registration> registration, Value value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.outline.cow().style = _value;
     }
 
@@ -117,7 +117,7 @@ export struct OutlineColorProperty : Property {
     OutlineColorProperty(Rc<Property::Registration> registration, Value value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.outline.cow().color = _value.visit(
             // https://drafts.csswg.org/css-ui/#valdef-outline-color-auto
             [&](Keywords::Auto) {
@@ -163,7 +163,7 @@ export struct OutlineOffsetProperty : Property {
     OutlineOffsetProperty(Rc<Property::Registration> registration, CalcValue<Length> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.outline.cow().offset = _value;
     }
 

--- a/src/vaev-engine/props/overflow.cpp
+++ b/src/vaev-engine/props/overflow.cpp
@@ -40,7 +40,7 @@ export struct OverflowXProperty : Property {
     OverflowXProperty(Rc<Property::Registration> registration, Overflow value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.overflows.x = _value;
     }
 
@@ -74,7 +74,7 @@ export struct OverflowYProperty : Property {
     OverflowYProperty(Rc<Property::Registration> registration, Overflow value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.overflows.y = _value;
     }
 
@@ -108,7 +108,7 @@ export struct OverflowBlockProperty : Property {
     OverflowBlockProperty(Rc<Property::Registration> registration, Overflow value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.overflows.block = _value;
     }
 
@@ -142,7 +142,7 @@ export struct OverflowInlineProperty : Property {
     OverflowInlineProperty(Rc<Property::Registration> registration, Overflow value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.overflows.inline_ = _value;
     }
 

--- a/src/vaev-engine/props/padding.cpp
+++ b/src/vaev-engine/props/padding.cpp
@@ -41,7 +41,7 @@ export struct PaddingTopProperty : Property {
     PaddingTopProperty(Rc<Property::Registration> registration, CalcValue<PercentOr<Length>> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.padding.cow().top = _value;
     }
 
@@ -74,7 +74,7 @@ export struct PaddingRightProperty : Property {
     PaddingRightProperty(Rc<Property::Registration> registration, CalcValue<PercentOr<Length>> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.padding.cow().end = _value;
     }
 
@@ -107,7 +107,7 @@ export struct PaddingBottomProperty : Property {
     PaddingBottomProperty(Rc<Property::Registration> registration, CalcValue<PercentOr<Length>> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.padding.cow().bottom = _value;
     }
 
@@ -140,7 +140,7 @@ export struct PaddingLeftProperty : Property {
     PaddingLeftProperty(Rc<Property::Registration> registration, CalcValue<PercentOr<Length>> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.padding.cow().start = _value;
     }
 
@@ -173,7 +173,7 @@ export struct PaddingInlineStartProperty : Property {
     PaddingInlineStartProperty(Rc<Property::Registration> registration, CalcValue<PercentOr<Length>> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.padding.cow().start = _value;
     }
 
@@ -206,7 +206,7 @@ export struct PaddingInlineEndProperty : Property {
     PaddingInlineEndProperty(Rc<Property::Registration> registration, CalcValue<PercentOr<Length>> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.padding.cow().end = _value;
     }
 

--- a/src/vaev-engine/props/positioned.cpp
+++ b/src/vaev-engine/props/positioned.cpp
@@ -40,7 +40,7 @@ export struct PositionProperty : Property {
     PositionProperty(Rc<Property::Registration> registration, Position value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.position = _value;
     }
 
@@ -74,7 +74,7 @@ export struct TopProperty : Property {
     TopProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.offsets.cow().top = _value;
     }
 
@@ -108,7 +108,7 @@ export struct RightProperty : Property {
     RightProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.offsets.cow().end = _value;
     }
 
@@ -142,7 +142,7 @@ export struct BottomProperty : Property {
     BottomProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.offsets.cow().bottom = _value;
     }
 
@@ -176,7 +176,7 @@ export struct LeftProperty : Property {
     LeftProperty(Rc<Property::Registration> registration, Width value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.offsets.cow().start = _value;
     }
 
@@ -210,7 +210,7 @@ export struct ZIndexProperty : Property {
     ZIndexProperty(Rc<Property::Registration> registration, ZIndex value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.zIndex = _value;
     }
 

--- a/src/vaev-engine/props/sizing.cpp
+++ b/src/vaev-engine/props/sizing.cpp
@@ -49,7 +49,7 @@ export struct BoxSizingProperty : Property {
     BoxSizingProperty(Rc<Property::Registration> registration, BoxSizing value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.boxSizing = _value;
     }
 
@@ -93,7 +93,7 @@ export struct WidthProperty : Property {
     WidthProperty(Rc<Property::Registration> registration, Size value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.sizing.cow().width = _value;
     }
 
@@ -138,7 +138,7 @@ export struct HeightProperty : Property {
     HeightProperty(Rc<Property::Registration> registration, Size value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.sizing.cow().height = _value;
     }
 
@@ -172,7 +172,7 @@ export struct MinWidthProperty : Property {
     MinWidthProperty(Rc<Property::Registration> registration, Size value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.sizing.cow().minWidth = _value;
     }
 
@@ -206,7 +206,7 @@ export struct MinHeightProperty : Property {
     MinHeightProperty(Rc<Property::Registration> registration, Size value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.sizing.cow().minHeight = _value;
     }
 
@@ -241,7 +241,7 @@ export struct MaxWidthProperty : Property {
     MaxWidthProperty(Rc<Property::Registration> registration, MaxSize value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.sizing.cow().maxWidth = _value;
     }
 
@@ -275,7 +275,7 @@ export struct MaxHeightProperty : Property {
     MaxHeightProperty(Rc<Property::Registration> registration, MaxSize value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.sizing.cow().maxHeight = _value;
     }
 

--- a/src/vaev-engine/props/svg.cpp
+++ b/src/vaev-engine/props/svg.cpp
@@ -48,7 +48,7 @@ export struct SvgXProperty : Property {
     SvgXProperty(Rc<Property::Registration> registration, PercentOr<Length> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().x = _value;
     }
 
@@ -90,7 +90,7 @@ export struct SvgYProperty : Property {
     SvgYProperty(Rc<Property::Registration> registration, PercentOr<Length> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().y = _value;
     }
 
@@ -132,7 +132,7 @@ export struct SvgCXProperty : Property {
     SvgCXProperty(Rc<Property::Registration> registration, PercentOr<Length> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().cx = _value;
     }
 
@@ -174,7 +174,7 @@ export struct SvgCYProperty : Property {
     SvgCYProperty(Rc<Property::Registration> registration, PercentOr<Length> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().cy = _value;
     }
 
@@ -216,7 +216,7 @@ export struct SvgRProperty : Property {
     SvgRProperty(Rc<Property::Registration> registration, PercentOr<Length> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().r = _value;
     }
 
@@ -263,7 +263,7 @@ export struct SvgFillProperty : Property {
     SvgFillProperty(Rc<Property::Registration> registration, SvgPaint value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().fill = _value;
     }
 
@@ -329,7 +329,7 @@ export struct SvgDProperty : Property {
     SvgDProperty(Rc<Property::Registration> registration, Union<String, None> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().d = _value;
     }
 
@@ -380,7 +380,7 @@ export struct SvgViewBoxProperty : Property {
     SvgViewBoxProperty(Rc<Property::Registration> registration, Opt<SvgViewBox> value)
         : Property(registration), _value(std::move(value)) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().viewBox = _value;
     }
 
@@ -427,7 +427,7 @@ export struct SvgStrokeProperty : Property {
     SvgStrokeProperty(Rc<Property::Registration> registration, SvgPaint value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().stroke = _value;
     }
 
@@ -466,7 +466,7 @@ export struct SvgStrokeOpacityProperty : Property {
     SvgStrokeOpacityProperty(Rc<Property::Registration> registration, Number value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().strokeOpacity = _value;
     }
 
@@ -518,7 +518,7 @@ export struct FillOpacityProperty : Property {
     FillOpacityProperty(Rc<Property::Registration> registration, Number value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().fillOpacity = _value;
     }
 
@@ -569,7 +569,7 @@ export struct StrokeWidthProperty : Property {
     StrokeWidthProperty(Rc<Property::Registration> registration, PercentOr<Length> value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.svg.cow().strokeWidth = _value;
     }
 

--- a/src/vaev-engine/props/table.cpp
+++ b/src/vaev-engine/props/table.cpp
@@ -38,8 +38,8 @@ export struct TableLayoutProperty : Property {
     TableLayoutProperty(Rc<Property::Registration> registration, TableLayout value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& s) const override {
-        s.table.cow().tableLayout = _value;
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
+        c.table.cow().tableLayout = _value;
     }
 
     void repr(Io::Emit& e) const override {
@@ -80,8 +80,8 @@ export struct CaptionSideProperty : Property {
     CaptionSideProperty(Rc<Property::Registration> registration, CaptionSide value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& s) const override {
-        s.table.cow().captionSide = _value;
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
+        c.table.cow().captionSide = _value;
     }
 
     void repr(Io::Emit& e) const override {

--- a/src/vaev-engine/props/text.cpp
+++ b/src/vaev-engine/props/text.cpp
@@ -72,7 +72,7 @@ export struct TextAlignProperty : Property {
     TextAlignProperty(Rc<Property::Registration> registration, TextAlign value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.text.cow().align = _value;
     }
 
@@ -129,7 +129,7 @@ export struct TextTransformProperty : Property {
     TextTransformProperty(Rc<Property::Registration> registration, TextTransform value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.text.cow().transform = _value;
     }
 
@@ -189,7 +189,7 @@ export struct WhiteSpaceProperty : Property {
     WhiteSpaceProperty(Rc<Property::Registration> registration, WhiteSpace value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.text.cow().whiteSpace = _value;
     }
 

--- a/src/vaev-engine/props/transform.cpp
+++ b/src/vaev-engine/props/transform.cpp
@@ -51,7 +51,7 @@ export struct TransformOriginProperty : Property {
     TransformOriginProperty(Rc<Property::Registration> registration, TransformOrigin value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.transform.cow().origin = _value;
     }
 
@@ -85,7 +85,7 @@ export struct TransformBoxProperty : Property {
     TransformBoxProperty(Rc<Property::Registration> registration, TransformBox value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.transform.cow().box = _value;
     }
 
@@ -163,7 +163,7 @@ export struct TransformProperty : Property {
     TransformProperty(Rc<Property::Registration> registration, Transform value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.transform.cow().transform = _value;
     }
 

--- a/src/vaev-engine/props/visibility.cpp
+++ b/src/vaev-engine/props/visibility.cpp
@@ -49,7 +49,7 @@ export struct VisibilityProperty : Property {
     VisibilityProperty(Rc<Property::Registration> registration, Visibility value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.visibility = _value;
     }
 
@@ -87,7 +87,7 @@ export struct OpacityProperty : Property {
     OpacityProperty(Rc<Property::Registration> registration, Number value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         c.opacity = _value;
     }
 
@@ -125,7 +125,7 @@ export struct ClipPathProperty : Property {
     ClipPathProperty(Rc<Property::Registration> registration, Value value)
         : Property(registration), _value(value) {}
 
-    void apply(ComputedValues& c) const override {
+    void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c) const override {
         if (auto clipShape = _value.is<BasicShape>())
             c.clip.cow() = *clipShape;
         else


### PR DESCRIPTION
The single argument apply() reduced boilerplate in the arguments but was illegal to call directly which is error-prone. Fixes error in `unset-val-001.html` wpt which was due to this mistake.