### PR TITLE
vaev-values: Fix uninit angle in FontStyle.

### DIFF
--- a/meta/wpt/golden
+++ b/meta/wpt/golden
@@ -91,3 +91,4 @@
 /css/css-color/t425-hsla-basic-a.xht
 /css/css-color/t425-hsla-values-b.xht
 /css/css-color/t43-svg-keywords-a.xht
+/css/css-fonts/italic-oblique-fallback.html

--- a/src/vaev-engine/values/font.cpp
+++ b/src/vaev-engine/values/font.cpp
@@ -125,7 +125,9 @@ struct ValueParser<FontWidth> {
 export struct FontStyle {
     using enum Gfx::FontStyle;
     Gfx::FontStyle val;
-    Angle obliqueAngle;
+
+    // The lack of an <angle> represents 14deg.
+    Angle obliqueAngle = Angle(14.0, Angle::Unit::DEGREE);
 
     constexpr FontStyle(Gfx::FontStyle named = NORMAL)
         : val(named) {


### PR DESCRIPTION
The relevant syntax is `oblique <angle [-90deg,90deg]>?` but we did not handle the missing angle case, so it was set to junk.