### PR TITLE
tests: Add reftests for BFC page fragmentation.

### DIFF
--- a/tests/css/break/page.xhtml
+++ b/tests/css/break/page.xhtml
@@ -1,0 +1,278 @@
+<tests>
+
+<test name="forced-page-break-bfc" flow="paginate" margins="minimum">
+    <container>
+        <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+        <head>
+            <style>
+                :root {
+                    background-color: white;
+                }
+
+                .box {
+                    width: auto;
+                    margin: 5px;
+                    height: 20px;
+                }
+
+                .box:nth-child(3n+1) { background-color: salmon; }
+                .box:nth-child(3n+2) { background-color: lightseagreen; }
+                .box:nth-child(3n+3) { background-color: rebeccapurple; }
+            </style>
+        </head>
+
+        <body>
+        <slot/>
+        </body>
+
+        </html>
+    </container>
+
+    <rendering>
+        <div class="box" style="break-after: page"></div>
+        <div class="box"></div>
+        <div class="box"></div>
+    </rendering>
+
+    <rendering>
+        <div class="box"></div>
+        <div class="box" style="break-before: page"></div>
+        <div class="box"></div>
+    </rendering>
+
+    <rendering>
+        <div class="box" style="break-after: avoid"></div>
+        <div class="box" style="break-before: page"></div>
+        <div class="box"></div>
+    </rendering>
+
+    <rendering>
+        <div class="box" style="break-after: avoid-page"></div>
+        <div class="box" style="break-before: page"></div>
+        <div class="box"></div>
+    </rendering>
+</test>
+
+<test name="unforced-page-break-bfc" flow="paginate" margins="minimum">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+    <head>
+        <style>
+            :root {
+                background-color: white;
+            }
+
+            .box {
+                width: auto;
+                margin: 5px;
+                height: 20px;
+            }
+
+            .box:nth-child(3n+1) { background-color: salmon; }
+            .box:nth-child(3n+2) { background-color: lightseagreen; }
+            .box:nth-child(3n+3) { background-color: rebeccapurple; }
+        </style>
+    </head>
+
+    <body>
+    <slot/>
+    </body>
+
+    </html>
+</container>
+
+<rendering>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box" style="break-after: page"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+</rendering>
+
+<rendering skip="true">
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box" style="break-after: avoid"></div>
+    <div class="box"></div>
+</rendering>
+
+<rendering skip="true">
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box" style="break-after: avoid-page"></div>
+    <div class="box"></div>
+</rendering>
+
+<rendering skip="true">
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box" style="break-before: avoid"></div>
+</rendering>
+
+<rendering skip="true">
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box" style="break-before: avoid-page"></div>
+</rendering>
+
+<error>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+</error>
+
+</test>
+
+<test name="forced-page-break-inside-bfc" flow="paginate" margins="minimum">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+    <head>
+        <style>
+            :root {
+                background-color: white;
+            }
+
+            body {
+                margin: 0;
+            }
+
+            .box {
+                width: auto;
+                margin: 5px;
+                height: 20px;
+            }
+
+            .box:nth-child(3n+1) { background-color: salmon; }
+            .box:nth-child(3n+2) { background-color: lightseagreen; }
+            .box:nth-child(3n+3) { background-color: rebeccapurple; }
+
+            .container {
+                background-color: gray;
+                padding: 5px;
+            }
+
+            .fake-box {
+                width: 180px;
+                margin: 5px;
+                height: 20px;
+            }
+
+            .fake-container-p1 {
+                background-color: gray;
+                padding: 5px;
+                width: 200px;
+                height: 200px;
+                break-after: page;
+            }
+
+            .fake-container-p2 {
+                background-color: gray;
+                padding: 5px;
+                padding-top: 0;
+                width: 200px;
+                height: 55px;
+            }
+        </style>
+    </head>
+
+    <body>
+        <slot/>
+    </body>
+
+    </html>
+</container>
+
+<rendering>
+    <div class="fake-container-p1">
+        <div class="fake-box" style="background-color: salmon"></div>
+    </div>
+
+    <div class="fake-container-p2">
+        <div class="fake-box" style="background-color: lightseagreen"></div>
+        <div class="fake-box" style="background-color: rebeccapurple"></div>
+    </div>
+</rendering>
+
+<rendering skip="true">
+    <div class="container">
+        <div class="box" style="break-after: page"></div>
+        <div class="box"></div>
+        <div class="box"></div>
+    </div>
+</rendering>
+
+</test>
+
+<test name="nop-forced-page-break" flow="paginate" margins="minimum">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+    <head>
+        <style>
+            :root {
+                background-color: white;
+            }
+
+            .box {
+                width: auto;
+                margin: 5px;
+                height: 20px;
+            }
+
+            .box:nth-child(3n+1) { background-color: salmon; }
+            .box:nth-child(3n+2) { background-color: lightseagreen; }
+            .box:nth-child(3n+3) { background-color: rebeccapurple; }
+        </style>
+    </head>
+
+    <body>
+    <slot/>
+    </body>
+
+    </html>
+</container>
+
+<rendering>
+    <div class="box" style="break-before: page"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+</rendering>
+
+<rendering skip="true">
+    <div class="box"></div>
+    <div class="box"></div>
+    <div class="box" style="break-after: page"></div>
+</rendering>
+
+</test>
+
+</tests>


### PR DESCRIPTION
Some of them are skipped for now and should be enabled in the breakpoint refactor.

The reference of `forced-page-break-inside-bfc` looks a bit counter intuitive but it follows the chrome and wkhtmltopdf behavior.

### Refest:
<img width="441" height="456" alt="image" src="https://github.com/user-attachments/assets/9b8f24a3-8b80-4186-aeb5-9c900e40c425" />

### Chrome (& wkhtmltopdf):
<img width="476" height="656" alt="image" src="https://github.com/user-attachments/assets/e9b7c148-7e54-4ef0-9c95-a2c85b2e7d2e" />
<img width="476" height="656" alt="image" src="https://github.com/user-attachments/assets/1dfeebee-707f-4ae3-b22b-2dead42a77f2" />

