### PR TITLE
vaev-layout: Added support for `break: avoid-page` + revert a bunch of commit that broke pagination.

### DIFF
--- a/src/vaev-engine/driver/print.cpp
+++ b/src/vaev-engine/driver/print.cpp
@@ -124,7 +124,7 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
         media.height / media.resolution.toDppx()
     };
 
-    usize pageNumber = 1;
+    usize pageNumber = 0;
     Layout::Breakpoint prevBreakpoint{
         .endIdx = 0,
         .advance = Layout::Breakpoint::Advance::WITHOUT_CHILDREN
@@ -166,7 +166,8 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
             .availableSpace = pageContent.size(),
             .containingBlock = pageContent.size(),
             .runningPosition = {&runningPosition},
-            .pageNumber = pageNumber,
+            // NOTE: CSS page counters are 1-indexed.
+            .pageNumber = pageNumber + 1,
         };
         contentTree.fc.enterDiscovery();
 

--- a/src/vaev-engine/driver/print.cpp
+++ b/src/vaev-engine/driver/print.cpp
@@ -20,9 +20,17 @@ using namespace Karm;
 
 namespace Vaev::Driver {
 
-void _paintCornerMargin(Style::PageComputedValues& pageStyle, Scene::Stack& stack, RectAu const& rect, Style::PageArea area, usize currentPage, Layout::RunningPositionMap& runningPosition) {
+struct PageLayoutInfos {
+    usize pageNumber;
+    RectAu pageRect;
+    RectAu pageContent;
+    Rc<Style::PageComputedValues> pageStyle;
+    Layout::Breakpoint breakpoint;
+};
+
+void _paintCornerMargin(PageLayoutInfos& infos, Scene::Stack& stack, RectAu const& rect, Style::PageArea area, Layout::RunningPositionMap& runningPosition) {
     Layout::Tree tree{
-        .root = Layout::buildElement(pageStyle.area(area), currentPage, runningPosition),
+        .root = Layout::buildElement(infos.pageStyle->area(area), infos.pageNumber, runningPosition),
         .viewport = Layout::Viewport{.small = rect.size()}
     };
     auto [_, frag] = Layout::layoutAndCommitRoot(
@@ -37,10 +45,10 @@ void _paintCornerMargin(Style::PageComputedValues& pageStyle, Scene::Stack& stac
     Layout::paint(frag, stack);
 }
 
-void _paintMainMargin(Style::PageComputedValues& pageStyle, Scene::Stack& stack, RectAu const& rect, Style::PageArea mainArea, Array<Style::PageArea, 3> subAreas, usize currentPage, Layout::RunningPositionMap& runningPosition) {
-    auto box = Layout::buildElement(pageStyle.area(mainArea), currentPage, runningPosition);
+void _paintMainMargin(PageLayoutInfos& infos, Scene::Stack& stack, RectAu const& rect, Style::PageArea mainArea, Array<Style::PageArea, 3> subAreas, Layout::RunningPositionMap& runningPosition) {
+    auto box = Layout::buildElement(infos.pageStyle->area(mainArea), infos.pageNumber, runningPosition);
     for (auto subArea : subAreas) {
-        box.add(Layout::buildElement(pageStyle.area(subArea), currentPage, runningPosition));
+        box.add(Layout::buildElement(infos.pageStyle->area(subArea), infos.pageNumber, runningPosition));
     }
     Layout::Tree tree{
         .root = std::move(box),
@@ -58,18 +66,18 @@ void _paintMainMargin(Style::PageComputedValues& pageStyle, Scene::Stack& stack,
     Layout::paint(frag, stack);
 }
 
-void _paintMargins(Style::PageComputedValues& pageStyle, RectAu pageRect, RectAu pageContent, Scene::Stack& stack, usize currentPage, Layout::RunningPositionMap& runningPosition) {
+void _paintMargins(PageLayoutInfos& infos, Scene::Stack& stack, Layout::RunningPositionMap& runningPosition) {
     // Compute all corner rects
-    auto topLeftMarginCornerRect = RectAu::fromTwoPoint(pageRect.topStart(), pageContent.topStart());
-    auto topRightMarginCornerRect = RectAu::fromTwoPoint(pageRect.topEnd(), pageContent.topEnd());
-    auto bottomLeftMarginCornerRect = RectAu::fromTwoPoint(pageRect.bottomStart(), pageContent.bottomStart());
-    auto bottomRightMarginCornerRect = RectAu::fromTwoPoint(pageRect.bottomEnd(), pageContent.bottomEnd());
+    auto topLeftMarginCornerRect = RectAu::fromTwoPoint(infos.pageRect.topStart(), infos.pageContent.topStart());
+    auto topRightMarginCornerRect = RectAu::fromTwoPoint(infos.pageRect.topEnd(), infos.pageContent.topEnd());
+    auto bottomLeftMarginCornerRect = RectAu::fromTwoPoint(infos.pageRect.bottomStart(), infos.pageContent.bottomStart());
+    auto bottomRightMarginCornerRect = RectAu::fromTwoPoint(infos.pageRect.bottomEnd(), infos.pageContent.bottomEnd());
 
     // Paint corners
-    _paintCornerMargin(pageStyle, stack, topLeftMarginCornerRect, Style::PageArea::TOP_LEFT_CORNER, currentPage, runningPosition);
-    _paintCornerMargin(pageStyle, stack, topRightMarginCornerRect, Style::PageArea::TOP_RIGHT_CORNER, currentPage, runningPosition);
-    _paintCornerMargin(pageStyle, stack, bottomLeftMarginCornerRect, Style::PageArea::BOTTOM_LEFT_CORNER, currentPage, runningPosition);
-    _paintCornerMargin(pageStyle, stack, bottomRightMarginCornerRect, Style::PageArea::BOTTOM_RIGHT_CORNER, currentPage, runningPosition);
+    _paintCornerMargin(infos, stack, topLeftMarginCornerRect, Style::PageArea::TOP_LEFT_CORNER, runningPosition);
+    _paintCornerMargin(infos, stack, topRightMarginCornerRect, Style::PageArea::TOP_RIGHT_CORNER, runningPosition);
+    _paintCornerMargin(infos, stack, bottomLeftMarginCornerRect, Style::PageArea::BOTTOM_LEFT_CORNER, runningPosition);
+    _paintCornerMargin(infos, stack, bottomRightMarginCornerRect, Style::PageArea::BOTTOM_RIGHT_CORNER, runningPosition);
 
     // Compute main area rects
     auto topRect = RectAu::fromTwoPoint(topLeftMarginCornerRect.topEnd(), topRightMarginCornerRect.bottomStart());
@@ -78,10 +86,10 @@ void _paintMargins(Style::PageComputedValues& pageStyle, RectAu pageRect, RectAu
     auto rightRect = RectAu::fromTwoPoint(topRightMarginCornerRect.bottomEnd(), bottomRightMarginCornerRect.topStart());
 
     // Paint main areas
-    _paintMainMargin(pageStyle, stack, topRect, Style::PageArea::TOP, {Style::PageArea::TOP_LEFT, Style::PageArea::TOP_CENTER, Style::PageArea::TOP_RIGHT}, currentPage, runningPosition);
-    _paintMainMargin(pageStyle, stack, bottomRect, Style::PageArea::BOTTOM, {Style::PageArea::BOTTOM_LEFT, Style::PageArea::BOTTOM_CENTER, Style::PageArea::BOTTOM_RIGHT}, currentPage, runningPosition);
-    _paintMainMargin(pageStyle, stack, leftRect, Style::PageArea::LEFT, {Style::PageArea::LEFT_TOP, Style::PageArea::LEFT_MIDDLE, Style::PageArea::LEFT_BOTTOM}, currentPage, runningPosition);
-    _paintMainMargin(pageStyle, stack, rightRect, Style::PageArea::RIGHT, {Style::PageArea::RIGHT_TOP, Style::PageArea::RIGHT_MIDDLE, Style::PageArea::RIGHT_BOTTOM}, currentPage, runningPosition);
+    _paintMainMargin(infos, stack, topRect, Style::PageArea::TOP, {Style::PageArea::TOP_LEFT, Style::PageArea::TOP_CENTER, Style::PageArea::TOP_RIGHT}, runningPosition);
+    _paintMainMargin(infos, stack, bottomRect, Style::PageArea::BOTTOM, {Style::PageArea::BOTTOM_LEFT, Style::PageArea::BOTTOM_CENTER, Style::PageArea::BOTTOM_RIGHT}, runningPosition);
+    _paintMainMargin(infos, stack, leftRect, Style::PageArea::LEFT, {Style::PageArea::LEFT_TOP, Style::PageArea::LEFT_MIDDLE, Style::PageArea::LEFT_BOTTOM}, runningPosition);
+    _paintMainMargin(infos, stack, rightRect, Style::PageArea::RIGHT, {Style::PageArea::RIGHT_TOP, Style::PageArea::RIGHT_MIDDLE, Style::PageArea::RIGHT_BOTTOM}, runningPosition);
 }
 
 struct PaginationContext {
@@ -92,96 +100,89 @@ struct PaginationContext {
     Rc<Style::ComputedValues> initialStyle;
 };
 
-struct PageLayoutInfos {
-    RectAu pageRect;
-    RectAu pageContent;
-    Rc<Style::PageComputedValues> pageStyle;
-};
+static InsetsAu _resolvePageMargin(Print::Margins marginSetting, Margin const& margin, RectAu pageRect) {
+    switch (marginSetting.named) {
+    case Print::Margins::NONE:
+        return {};
 
-Pair<Vec<Layout::Breakpoint>, Vec<PageLayoutInfos>> collectBreakPointsAndRunningPositions(Layout::RunningPositionMap& runningPosition, PaginationContext& context) {
-    usize pageNumber = 0;
-    Layout::Breakpoint prevBreakpoint{
-        .endIdx = 0,
-        .advance = Layout::Breakpoint::Advance::WITHOUT_CHILDREN
-    };
+    case Print::Margins::DEFAULT: {
+        Layout::Resolver resolver{};
+        return {
+            resolver.resolve(margin.top, pageRect.height),
+            resolver.resolve(margin.end, pageRect.width),
+            resolver.resolve(margin.bottom, pageRect.height),
+            resolver.resolve(margin.start, pageRect.width),
+        };
+    }
 
-    Vec<Layout::Breakpoint> breakpoints = {prevBreakpoint};
+    case Print::Margins::MINIMUM:
+        // FIXME: Supposed to be the minimum supported by the printer
+        return {};
+
+    case Print::Margins::CUSTOM:
+        return marginSetting.custom.cast<Au>();
+
+    default:
+        unreachable();
+    }
+}
+
+Vec<PageLayoutInfos> collectBreakPointsAndRunningPositions(Layout::RunningPositionMap& runningPosition, PaginationContext& context) {
+    auto startOfDocument = Layout::Breakpoint::startOfDocument();
     Vec<PageLayoutInfos> pageInfos = {};
 
     while (true) {
         Style::Page page{
             .name = ""s,
-            .number = pageNumber++,
+            .number = pageInfos.len() + 1,
             .blank = false,
         };
 
-        Rc<Style::PageComputedValues> pageStyle = context.computer.computeFor(*context.initialStyle, page);
-        RectAu pageRect{
-            context.media.width / context.media.resolution.toDppx(),
-            context.media.height / context.media.resolution.toDppx()
-        };
-
-        auto pageSize = pageRect.size().cast<f64>();
-
-        auto pageStack = makeRc<Scene::Stack>();
-
-        InsetsAu pageMargin;
-
-        if (context.settings.margins == Print::Margins::DEFAULT) {
-            Layout::Resolver resolver{};
-            pageMargin = {
-                resolver.resolve(pageStyle->style->margin->top, pageRect.height),
-                resolver.resolve(pageStyle->style->margin->end, pageRect.width),
-                resolver.resolve(pageStyle->style->margin->bottom, pageRect.height),
-                resolver.resolve(pageStyle->style->margin->start, pageRect.width),
-            };
-        } else if (context.settings.margins == Print::Margins::CUSTOM) {
-            pageMargin = context.settings.margins.custom.template cast<Au>();
-        } else if (context.settings.margins == Print::Margins::MINIMUM) {
-            pageMargin = {};
-        }
-
-        RectAu pageContent = pageRect.shrink(pageMargin);
-
-        pageInfos.pushBack({pageRect, pageContent, pageStyle});
-
-        Layout::Viewport vp{
-            .small = pageContent.size(),
-        };
-
-        context.contentTree.viewport = vp;
-        context.contentTree.fc = {pageContent.size()};
+        auto pageStyle = context.computer.computeFor(*context.initialStyle, page);
+        auto pageRect = RectAu{context.media.scaledViewport()};
+        auto pageContent = pageRect.shrink(
+            _resolvePageMargin(context.settings.margins, *pageStyle->style->margin, pageRect)
+        );
 
         Layout::Input pageLayoutInput{
             .knownSize = {pageContent.width, NONE},
             .position = pageContent.topStart(),
             .availableSpace = pageContent.size(),
             .containingBlock = pageContent.size(),
-            .pageNumber = pageNumber,
+            .runningPosition = {&runningPosition},
+            .pageNumber = page.number,
+            .breakpointTraverser = Layout::BreakpointTraverser(pageInfos ? &last(pageInfos).breakpoint : &startOfDocument),
         };
-        pageLayoutInput.runningPosition = {&runningPosition};
+
+        context.contentTree.viewport = {
+            .small = pageContent.size(),
+        };
+        context.contentTree.fc = {pageContent.size()};
         context.contentTree.fc.enterDiscovery();
 
         auto outDiscovery = Layout::layoutRoot(
             context.contentTree,
-            pageLayoutInput.withBreakpointTraverser(Layout::BreakpointTraverser(&prevBreakpoint))
+            pageLayoutInput
         );
+
+        context.contentTree.fc.leaveDiscovery();
 
         Layout::Breakpoint currBreakpoint =
             outDiscovery.completelyLaidOut
                 ? Layout::Breakpoint::classB(1, false)
                 : outDiscovery.breakpoint.unwrap();
 
-        context.contentTree.fc.leaveDiscovery();
+        pageInfos.pushBack({
+            page.number,
+            pageRect,
+            pageContent,
+            pageStyle,
+            currBreakpoint,
+        });
 
-        breakpoints.pushBack(currBreakpoint);
         if (outDiscovery.completelyLaidOut)
-            break;
-
-        prevBreakpoint = std::move(currBreakpoint);
+            return pageInfos;
     }
-
-    return {breakpoints, pageInfos};
 }
 
 export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Print::Settings const& settings) {
@@ -200,7 +201,6 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
     // MARK: Page and Margins --------------------------------------------------
 
     auto initialStyle = dom->registeredPropertySet.initialComputedValues();
-    initialStyle->color = Gfx::BLACK;
     initialStyle->setCustomProp("-vaev-url", {Css::Token::string(Io::format("\"{}\"", dom->url()))});
     initialStyle->setCustomProp("-vaev-title", {Css::Token::string(Io::format("\"{}\"", dom->title()))});
     initialStyle->setCustomProp("-vaev-datetime", {Css::Token::string(Io::format("\"{}\"", Sys::now()))});
@@ -211,7 +211,7 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
         Layout::buildDocument(dom),
     };
 
-    Layout::RunningPositionMap runningPosition = {}; // Mapping the different Running positions to their respective names and their page.
+    Layout::RunningPositionMap runningPosition = {};
     PaginationContext paginationContext{
         .contentTree = contentTree,
         .media = media,
@@ -219,32 +219,38 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
         .computer = computer,
         .initialStyle = initialStyle,
     };
-    auto [breakpoints, pageInfos] = collectBreakPointsAndRunningPositions(runningPosition, paginationContext);
 
-    for (usize pageNumber = 0; pageNumber < breakpoints.len() - 1; pageNumber++) {
-        Style::Page page{
-            .name = ""s,
-            .number = pageNumber,
-            .blank = false,
-        };
-        auto pageStack = makeRc<Scene::Stack>();
+    auto startOfDocument = Layout::Breakpoint::startOfDocument();
+    auto pageInfos = collectBreakPointsAndRunningPositions(runningPosition, paginationContext);
 
-        auto infos = pageInfos[pageNumber];
+    for (auto [infos, i] : iter(pageInfos) | Index()) {
         Layout::Input pageLayoutInput{
             .knownSize = {infos.pageContent.width, NONE},
             .position = infos.pageContent.topStart(),
             .availableSpace = infos.pageContent.size(),
             .containingBlock = infos.pageContent.size(),
-            .pageNumber = pageNumber,
+            .pageNumber = infos.pageNumber,
+            .breakpointTraverser = {
+                i == 0 ? &startOfDocument : &pageInfos[i - 1].breakpoint,
+                &infos.breakpoint,
+            }
         };
-        auto [outFragmentation, fragment] = Layout::layoutAndCommitRoot(
+
+        contentTree.viewport = {
+            .small = infos.pageContent.size(),
+        };
+        auto [_, fragment] = Layout::layoutAndCommitRoot(
             contentTree,
             pageLayoutInput
-                .withBreakpointTraverser(Layout::BreakpointTraverser(&breakpoints[pageNumber], &breakpoints[pageNumber + 1]))
         );
 
+        auto pageStack = makeRc<Scene::Stack>();
         if (settings.headerFooter and settings.margins != Print::Margins::NONE)
-            _paintMargins(*pageInfos[pageNumber].pageStyle, pageInfos[pageNumber].pageRect, pageInfos[pageNumber].pageContent, *pageStack, page.number, runningPosition);
+            _paintMargins(
+                infos,
+                *pageStack,
+                runningPosition
+            );
 
         Layout::paint(fragment, *pageStack);
         pageStack->prepare();
@@ -253,7 +259,7 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
             settings.pageSize().cast<f64>(),
             makeRc<Scene::Transform>(
                 pageStack,
-                Math::Trans2f::scale(media.resolution.toDppx())
+                Math::Trans2f::scale(media.scale())
             )
         );
     }

--- a/src/vaev-engine/driver/print.cpp
+++ b/src/vaev-engine/driver/print.cpp
@@ -84,11 +84,105 @@ void _paintMargins(Style::PageComputedValues& pageStyle, RectAu pageRect, RectAu
     _paintMainMargin(pageStyle, stack, rightRect, Style::PageArea::RIGHT, {Style::PageArea::RIGHT_TOP, Style::PageArea::RIGHT_MIDDLE, Style::PageArea::RIGHT_BOTTOM}, currentPage, runningPosition);
 }
 
+struct PaginationContext {
+    Layout::Tree& contentTree;
+    Style::Media& media;
+    Print::Settings const& settings;
+    Style::Computer& computer;
+    Rc<Style::ComputedValues> initialStyle;
+};
+
 struct PageLayoutInfos {
     RectAu pageRect;
     RectAu pageContent;
     Rc<Style::PageComputedValues> pageStyle;
 };
+
+Pair<Vec<Layout::Breakpoint>, Vec<PageLayoutInfos>> collectBreakPointsAndRunningPositions(Layout::RunningPositionMap& runningPosition, PaginationContext& context) {
+    usize pageNumber = 0;
+    Layout::Breakpoint prevBreakpoint{
+        .endIdx = 0,
+        .advance = Layout::Breakpoint::Advance::WITHOUT_CHILDREN
+    };
+
+    Vec<Layout::Breakpoint> breakpoints = {prevBreakpoint};
+    Vec<PageLayoutInfos> pageInfos = {};
+
+    while (true) {
+        Style::Page page{
+            .name = ""s,
+            .number = pageNumber++,
+            .blank = false,
+        };
+
+        Rc<Style::PageComputedValues> pageStyle = context.computer.computeFor(*context.initialStyle, page);
+        RectAu pageRect{
+            context.media.width / context.media.resolution.toDppx(),
+            context.media.height / context.media.resolution.toDppx()
+        };
+
+        auto pageSize = pageRect.size().cast<f64>();
+
+        auto pageStack = makeRc<Scene::Stack>();
+
+        InsetsAu pageMargin;
+
+        if (context.settings.margins == Print::Margins::DEFAULT) {
+            Layout::Resolver resolver{};
+            pageMargin = {
+                resolver.resolve(pageStyle->style->margin->top, pageRect.height),
+                resolver.resolve(pageStyle->style->margin->end, pageRect.width),
+                resolver.resolve(pageStyle->style->margin->bottom, pageRect.height),
+                resolver.resolve(pageStyle->style->margin->start, pageRect.width),
+            };
+        } else if (context.settings.margins == Print::Margins::CUSTOM) {
+            pageMargin = context.settings.margins.custom.template cast<Au>();
+        } else if (context.settings.margins == Print::Margins::MINIMUM) {
+            pageMargin = {};
+        }
+
+        RectAu pageContent = pageRect.shrink(pageMargin);
+
+        pageInfos.pushBack({pageRect, pageContent, pageStyle});
+
+        Layout::Viewport vp{
+            .small = pageContent.size(),
+        };
+
+        context.contentTree.viewport = vp;
+        context.contentTree.fc = {pageContent.size()};
+
+        Layout::Input pageLayoutInput{
+            .knownSize = {pageContent.width, NONE},
+            .position = pageContent.topStart(),
+            .availableSpace = pageContent.size(),
+            .containingBlock = pageContent.size(),
+            .pageNumber = pageNumber,
+        };
+        pageLayoutInput.runningPosition = {&runningPosition};
+        context.contentTree.fc.enterDiscovery();
+
+        auto outDiscovery = Layout::layoutRoot(
+            context.contentTree,
+            pageLayoutInput.withBreakpointTraverser(Layout::BreakpointTraverser(&prevBreakpoint))
+        );
+
+        Layout::Breakpoint currBreakpoint =
+            outDiscovery.completelyLaidOut
+                ? Layout::Breakpoint::classB(1, false)
+                : outDiscovery.breakpoint.unwrap();
+
+        context.contentTree.fc.leaveDiscovery();
+
+        breakpoints.pushBack(currBreakpoint);
+        if (outDiscovery.completelyLaidOut)
+            break;
+
+        prevBreakpoint = std::move(currBreakpoint);
+    }
+
+    return {breakpoints, pageInfos};
+}
 
 export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Print::Settings const& settings) {
     auto media = Style::Media::forPrint(settings);
@@ -118,77 +212,41 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
     };
 
     Layout::RunningPositionMap runningPosition = {}; // Mapping the different Running positions to their respective names and their page.
-
-    RectAu pageRect{
-        media.width / media.resolution.toDppx(),
-        media.height / media.resolution.toDppx()
+    PaginationContext paginationContext{
+        .contentTree = contentTree,
+        .media = media,
+        .settings = settings,
+        .computer = computer,
+        .initialStyle = initialStyle,
     };
+    auto [breakpoints, pageInfos] = collectBreakPointsAndRunningPositions(runningPosition, paginationContext);
 
-    usize pageNumber = 0;
-    Layout::Breakpoint prevBreakpoint{
-        .endIdx = 0,
-        .advance = Layout::Breakpoint::Advance::WITHOUT_CHILDREN
-    };
-
-    while (true) {
+    for (usize pageNumber = 0; pageNumber < breakpoints.len() - 1; pageNumber++) {
         Style::Page page{
             .name = ""s,
             .number = pageNumber,
             .blank = false,
         };
+        auto pageStack = makeRc<Scene::Stack>();
 
-        Rc<Style::PageComputedValues> pageStyle = computer.computeFor(*initialStyle, page);
-
-        InsetsAu pageMargin;
-
-        if (settings.margins == Print::Margins::DEFAULT) {
-            Layout::Resolver resolver{};
-            pageMargin = {
-                resolver.resolve(pageStyle->style->margin->top, pageRect.height),
-                resolver.resolve(pageStyle->style->margin->end, pageRect.width),
-                resolver.resolve(pageStyle->style->margin->bottom, pageRect.height),
-                resolver.resolve(pageStyle->style->margin->start, pageRect.width),
-            };
-        } else if (settings.margins == Print::Margins::CUSTOM) {
-            pageMargin = settings.margins.custom.template cast<Au>();
-        } else if (settings.margins == Print::Margins::MINIMUM) {
-            pageMargin = {};
-        }
-
-        RectAu pageContent = pageRect.shrink(pageMargin);
-
-        contentTree.viewport = {.small = pageContent.size()};
-        contentTree.fc = {pageContent.size()};
-
+        auto infos = pageInfos[pageNumber];
         Layout::Input pageLayoutInput{
-            .knownSize = {pageContent.width, NONE},
-            .position = pageContent.topStart(),
-            .availableSpace = pageContent.size(),
-            .containingBlock = pageContent.size(),
-            .runningPosition = {&runningPosition},
-            // NOTE: CSS page counters are 1-indexed.
-            .pageNumber = pageNumber + 1,
+            .knownSize = {infos.pageContent.width, NONE},
+            .position = infos.pageContent.topStart(),
+            .availableSpace = infos.pageContent.size(),
+            .containingBlock = infos.pageContent.size(),
+            .pageNumber = pageNumber,
         };
-        contentTree.fc.enterDiscovery();
-
-        auto [output, frag] = Layout::layoutAndCommitRoot(
+        auto [outFragmentation, fragment] = Layout::layoutAndCommitRoot(
             contentTree,
-            pageLayoutInput.withBreakpointTraverser(Layout::BreakpointTraverser(&prevBreakpoint))
+            pageLayoutInput
+                .withBreakpointTraverser(Layout::BreakpointTraverser(&breakpoints[pageNumber], &breakpoints[pageNumber + 1]))
         );
 
-        Layout::Breakpoint currBreakpoint =
-            output.completelyLaidOut
-                ? Layout::Breakpoint::classB(1, false)
-                : output.breakpoint.unwrap();
-
-        contentTree.fc.leaveDiscovery();
-
-        auto pageStack = makeRc<Scene::Stack>();
         if (settings.headerFooter and settings.margins != Print::Margins::NONE)
-            _paintMargins(*pageStyle, pageRect, pageContent, *pageStack, page.number, runningPosition);
+            _paintMargins(*pageInfos[pageNumber].pageStyle, pageInfos[pageNumber].pageRect, pageInfos[pageNumber].pageContent, *pageStack, page.number, runningPosition);
 
-        Layout::paint(frag, *pageStack);
-
+        Layout::paint(fragment, *pageStack);
         pageStack->prepare();
 
         co_yield Print::Page(
@@ -198,12 +256,6 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
                 Math::Trans2f::scale(media.resolution.toDppx())
             )
         );
-
-        if (output.completelyLaidOut)
-            break;
-
-        prevBreakpoint = output.breakpoint.take();
-        pageNumber++;
     }
 }
 

--- a/src/vaev-engine/layout/base/breaks.cpp
+++ b/src/vaev-engine/layout/base/breaks.cpp
@@ -152,6 +152,13 @@ export struct Breakpoint {
         return b;
     }
 
+    static Breakpoint startOfDocument() {
+        return {
+            .endIdx = 0,
+            .advance = Advance::WITHOUT_CHILDREN
+        };
+    }
+
     static Breakpoint overflow() {
         // this is a placeholder breakpoint and should be overriden
         return {

--- a/src/vaev-engine/layout/base/running-position.cpp
+++ b/src/vaev-engine/layout/base/running-position.cpp
@@ -79,6 +79,7 @@ struct RunningPositionMap {
     }
 
     Slice<RunningPositionInfo> _searchPage(Slice<RunningPositionInfo> list, usize page) {
+        page++; // pages are 1-indexed
         // binary search of all running positions that match the page
 
         auto res = search(list, [&](RunningPositionInfo const& info) {

--- a/src/vaev-engine/layout/base/running-position.cpp
+++ b/src/vaev-engine/layout/base/running-position.cpp
@@ -18,19 +18,20 @@ namespace Vaev::Layout {
 // MARK: RunningPos ------------------------------------------------------------
 
 export struct RunningPositionInfo {
-    usize page;
+    usize pageNumber;
     RunningPosition running;
     Dom::OriginatingElement element;
 
     RunningPositionInfo(usize page, RunningPosition running, Dom::OriginatingElement element)
-        : page(page), running(running), element(element) {
+        : pageNumber(page), running(running), element(element) {
     }
 
     void repr(Io::Emit& e) const {
-        e("runningPosInfos \nrunning:{} \npage:{} \nelement:{}", running, page, element);
+        e("(runningPosInfos running:{} page:{} element:{})", running, pageNumber, element);
     }
 };
 
+// Mapping the different Running positions to their respective names and their page.
 struct RunningPositionMap {
     Map<CustomIdent, Vec<RunningPositionInfo>> content;
 
@@ -48,7 +49,7 @@ struct RunningPositionMap {
     }
 
     // https://www.w3.org/TR/css-gcpm-3/#using-named-strings
-    Res<RunningPositionInfo> match(ElementContent elt, usize currentPage = 0) {
+    Res<RunningPositionInfo> match(ElementContent elt, usize pageNumber) {
         auto id = elt.customIdent;
         auto const& list = try$(content.lookup(id).okOr(Error::notFound("element not found")));
 
@@ -59,7 +60,7 @@ struct RunningPositionMap {
         case ElementContent::Target::START:
             for (usize i = 0; i < list.len(); i++) {
                 auto elt = list[i];
-                if (elt.page == currentPage and i > 0) {
+                if (elt.pageNumber == pageNumber and i > 0) {
                     return Ok(list[i - 1]);
                 }
             }
@@ -67,46 +68,41 @@ struct RunningPositionMap {
 
         case ElementContent::Target::FIRST:
         case ElementContent::Target::FIRST_EXCEPT: {
-            auto elements = _searchPage(list, currentPage);
+            auto elements = _searchPage(list, pageNumber);
             return Ok(elements[0]);
         }
 
         case ElementContent::Target::LAST: {
-            auto elements = _searchPage(list, currentPage);
+            auto elements = _searchPage(list, pageNumber);
             return Ok(elements[elements.len() - 1]);
         }
         }
     }
 
     Slice<RunningPositionInfo> _searchPage(Slice<RunningPositionInfo> list, usize page) {
-        page++; // pages are 1-indexed
         // binary search of all running positions that match the page
-
         auto res = search(list, [&](RunningPositionInfo const& info) {
-            if (info.page == page) {
+            if (info.pageNumber == page) {
                 return std::strong_ordering::equal;
             }
-            return info.page <=> page;
+            return info.pageNumber <=> page;
         });
 
-        if (not res) {
+        if (not res)
             return sub(list, 0, 1);
-        }
 
         // a random element of the page
         auto index = res.take();
 
         // search left side for first element of the page
         usize l = index;
-        while (l > 0 and list[l - 1].page == page) {
+        while (l > 0 and list[l - 1].pageNumber == page)
             l--;
-        }
 
         // search right side for last element of the page
         usize r = index;
-        while (r < list.len() - 1 and list[r + 1].page == page) {
+        while (r < list.len() - 1 and list[r + 1].pageNumber == page)
             r++;
-        }
 
         return sub(list, l, r + 1);
     }

--- a/src/vaev-engine/layout/block.cpp
+++ b/src/vaev-engine/layout/block.cpp
@@ -54,9 +54,9 @@ Res<None, Output> processBreakpointsAfterChild(Fragmentainer& fc, Breakpoint& cu
     // BREAK CLASS A
     if (not isLastChild) {
         bool breakIsAvoided =
-            parentBox.style->break_->inside == BreakInside::AVOID or
-            childBox.style->break_->after == BreakBetween::AVOID or
-            (not isLastChild and parentBox.children()[childIndex + 1].style->break_->before == BreakBetween::AVOID);
+            oneOf(parentBox.style->break_->inside, BreakInside::AVOID, BreakInside::AVOID_PAGE) or
+            oneOf(childBox.style->break_->after, BreakBetween::AVOID, BreakBetween::AVOID_PAGE) or
+            (not isLastChild and oneOf(parentBox.children()[childIndex + 1].style->break_->before, BreakBetween::AVOID, BreakBetween::AVOID_PAGE));
 
         currentBreakpoint.overrideIfBetter(
             Breakpoint::classB(
@@ -329,7 +329,7 @@ struct BlockFormatingContext : FormatingContext {
                 tree.fc,
                 currentBreakpoint,
                 i,
-                box.style->break_->inside == BreakInside::AVOID,
+                oneOf(box.style->break_->inside, BreakInside::AVOID, BreakInside::AVOID_PAGE),
                 output.breakpoint
             );
 

--- a/src/vaev-engine/layout/builder/mod.cpp
+++ b/src/vaev-engine/layout/builder/mod.cpp
@@ -963,7 +963,7 @@ export Box buildElement(Dom::OriginatingElement& el) {
     return buildElement(el.unwrap<Gc::Ref<Dom::Element>>());
 }
 
-export Box buildElement(Gc::Ref<Dom::PseudoElement> el, usize currentPage, RunningPositionMap& runningPos) {
+export Box buildElement(Gc::Ref<Dom::PseudoElement> el, usize pageNumber, RunningPositionMap& runningPos) {
     auto style = el->computedValues();
     auto proseStyle = _proseStyleFromStyle(*style, style->fontFace);
 
@@ -973,7 +973,7 @@ export Box buildElement(Gc::Ref<Dom::PseudoElement> el, usize currentPage, Runni
         return Box{style, prose, el};
     } else if (style->content.is<ElementContent>()) {
         auto elt = style->content.unwrap<ElementContent>();
-        if (auto infos = runningPos.match(elt, currentPage)) {
+        if (auto infos = runningPos.match(elt, pageNumber)) {
             Box box = buildElement(infos.unwrap().element);
             box.style->position = Keywords::STATIC;
             return box;
@@ -981,7 +981,7 @@ export Box buildElement(Gc::Ref<Dom::PseudoElement> el, usize currentPage, Runni
     } else if (auto elt = style->content.is<Counter>()) {
         if (elt->type == Counter::Type::PAGE) {
             auto prose = makeRc<Gfx::Prose>(proseStyle);
-            prose->append(Io::toStr(currentPage + 1).str());
+            prose->append(Io::toStr(pageNumber).str());
             return Box{style, prose, el};
         }
     }
@@ -995,7 +995,7 @@ export Box buildDocument(Gc::Ref<Dom::Document> doc) {
         return {doc->registeredPropertySet.initialComputedValues(), NONE};
     auto root = buildElement(el.upgrade());
 
-    logDebugIf(dumpBoxes, "{}", root);
+    logDebugIf(dumpBoxes, "boxes: {}", root);
 
     return root;
 }

--- a/src/vaev-engine/layout/table.cpp
+++ b/src/vaev-engine/layout/table.cpp
@@ -1411,7 +1411,7 @@ export struct TableFormatingContext : FormatingContext {
         }
 
         if (tree.fc.isDiscoveryMode()) {
-            if (cellBox->style->break_->inside == BreakInside::AVOID) {
+            if (oneOf(cellBox->style->break_->inside, BreakInside::AVOID, BreakInside::AVOID_PAGE)) {
                 outputCell.breakpoint.unwrap().withAppeal(Breakpoint::Appeal::AVOID);
             }
         }
@@ -1535,15 +1535,15 @@ export struct TableFormatingContext : FormatingContext {
     bool handleUnforcedBreakpointsInsideAndAfterRow(Box& box, Breakpoint& currentBreakpoint, RowOutput outputRow, usize i, Vec2Au fragmentainerSize) {
         bool rowIsFreelyFragmentable = isFreelyFragmentableRow(i, fragmentainerSize);
 
-        bool avoidBreakInsideTable = box.style->break_->inside == BreakInside::AVOID;
+        bool avoidBreakInsideTable = oneOf(box.style->break_->inside, BreakInside::AVOID, BreakInside::AVOID_PAGE);
 
         bool avoidBreakInsideRow =
             rowGroupIdxs[i].axisIdx and
-            rows[rowGroupIdxs[i].axisIdx.unwrap()].el.style->break_->inside == BreakInside::AVOID;
+            oneOf(rows[rowGroupIdxs[i].axisIdx.unwrap()].el.style->break_->inside, BreakInside::AVOID, BreakInside::AVOID_PAGE);
 
         bool avoidBreakInsideRowGroup =
             rowGroupIdxs[i].groupIdx and
-            rowGroups[rowGroupIdxs[i].groupIdx.unwrap()].el.style->break_->inside == BreakInside::AVOID;
+            oneOf(rowGroups[rowGroupIdxs[i].groupIdx.unwrap()].el.style->break_->inside, BreakInside::AVOID, BreakInside::AVOID_PAGE);
 
         if (rowIsFreelyFragmentable) {
             // breakpoint inside of row, take in consideration ALL breakpoints

--- a/src/vaev-engine/style/media.cpp
+++ b/src/vaev-engine/style/media.cpp
@@ -280,6 +280,17 @@ export struct Media {
     Vec2Au viewportSize() const {
         return {width, height};
     }
+
+    f64 scale() const {
+        return resolution.toDppx();
+    }
+
+    Vec2Au scaledViewport() const {
+        return {
+            width / scale(),
+            height / scale()
+        };
+    }
 };
 
 // MARK: Media Features --------------------------------------------------------

--- a/src/vaev-engine/style/page.cpp
+++ b/src/vaev-engine/style/page.cpp
@@ -149,7 +149,7 @@ export struct PageSelector {
         for (auto const& pseudo : pseudos) {
             switch (pseudo) {
             case PagePseudo::FIRST:
-                if (not page.number)
+                if (page.number != 1)
                     return false;
                 break;
             case PagePseudo::BLANK:

--- a/src/vaev-engine/style/page.cpp
+++ b/src/vaev-engine/style/page.cpp
@@ -149,7 +149,7 @@ export struct PageSelector {
         for (auto const& pseudo : pseudos) {
             switch (pseudo) {
             case PagePseudo::FIRST:
-                if (page.number != 1)
+                if (not page.number)
                     return false;
                 break;
             case PagePseudo::BLANK:

--- a/tests/css/break/page.xhtml
+++ b/tests/css/break/page.xhtml
@@ -1,57 +1,64 @@
 <tests>
-
 <test name="forced-page-break-bfc" flow="paginate" margins="minimum">
-    <container>
-        <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
 
-        <head>
-            <style>
-                :root {
-                    background-color: white;
-                }
+    <head>
+        <style>
+            :root {
+                background-color: white;
+            }
 
-                .box {
-                    width: auto;
-                    margin: 5px;
-                    height: 20px;
-                }
+            .box {
+                width: auto;
+                margin: 5px;
+                height: 20px;
+            }
 
-                .box:nth-child(3n+1) { background-color: salmon; }
-                .box:nth-child(3n+2) { background-color: lightseagreen; }
-                .box:nth-child(3n+3) { background-color: rebeccapurple; }
-            </style>
-        </head>
+            .box:nth-child(3n+1) {
+                background-color: salmon;
+            }
 
-        <body>
-        <slot/>
-        </body>
+            .box:nth-child(3n+2) {
+                background-color: lightseagreen;
+            }
 
-        </html>
-    </container>
+            .box:nth-child(3n+3) {
+                background-color: rebeccapurple;
+            }
+        </style>
+    </head>
 
-    <rendering>
-        <div class="box" style="break-after: page"></div>
-        <div class="box"></div>
-        <div class="box"></div>
-    </rendering>
+    <body>
+        <slot />
+    </body>
 
-    <rendering>
-        <div class="box"></div>
-        <div class="box" style="break-before: page"></div>
-        <div class="box"></div>
-    </rendering>
+    </html>
+</container>
 
-    <rendering>
-        <div class="box" style="break-after: avoid"></div>
-        <div class="box" style="break-before: page"></div>
-        <div class="box"></div>
-    </rendering>
+<rendering>
+    <div class="box" style="break-after: page"></div>
+    <div class="box"></div>
+    <div class="box"></div>
+</rendering>
 
-    <rendering>
-        <div class="box" style="break-after: avoid-page"></div>
-        <div class="box" style="break-before: page"></div>
-        <div class="box"></div>
-    </rendering>
+<rendering>
+    <div class="box"></div>
+    <div class="box" style="break-before: page"></div>
+    <div class="box"></div>
+</rendering>
+
+<rendering>
+    <div class="box" style="break-after: avoid"></div>
+    <div class="box" style="break-before: page"></div>
+    <div class="box"></div>
+</rendering>
+
+<rendering>
+    <div class="box" style="break-after: avoid-page"></div>
+    <div class="box" style="break-before: page"></div>
+    <div class="box"></div>
+</rendering>
 </test>
 
 <test name="unforced-page-break-bfc" flow="paginate" margins="minimum">
@@ -70,14 +77,22 @@
                 height: 20px;
             }
 
-            .box:nth-child(3n+1) { background-color: salmon; }
-            .box:nth-child(3n+2) { background-color: lightseagreen; }
-            .box:nth-child(3n+3) { background-color: rebeccapurple; }
+            .box:nth-child(3n+1) {
+                background-color: salmon;
+            }
+
+            .box:nth-child(3n+2) {
+                background-color: lightseagreen;
+            }
+
+            .box:nth-child(3n+3) {
+                background-color: rebeccapurple;
+            }
         </style>
     </head>
 
     <body>
-    <slot/>
+        <slot />
     </body>
 
     </html>
@@ -94,7 +109,7 @@
     <div class="box"></div>
 </rendering>
 
-<rendering skip="true">
+<rendering>
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
@@ -105,7 +120,7 @@
     <div class="box"></div>
 </rendering>
 
-<rendering skip="true">
+<rendering>
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
@@ -116,7 +131,7 @@
     <div class="box"></div>
 </rendering>
 
-<rendering skip="true">
+<rendering>
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
@@ -127,7 +142,7 @@
     <div class="box" style="break-before: avoid"></div>
 </rendering>
 
-<rendering skip="true">
+<rendering>
     <div class="box"></div>
     <div class="box"></div>
     <div class="box"></div>
@@ -171,9 +186,17 @@
                 height: 20px;
             }
 
-            .box:nth-child(3n+1) { background-color: salmon; }
-            .box:nth-child(3n+2) { background-color: lightseagreen; }
-            .box:nth-child(3n+3) { background-color: rebeccapurple; }
+            .box:nth-child(3n+1) {
+                background-color: salmon;
+            }
+
+            .box:nth-child(3n+2) {
+                background-color: lightseagreen;
+            }
+
+            .box:nth-child(3n+3) {
+                background-color: rebeccapurple;
+            }
 
             .container {
                 background-color: gray;
@@ -205,7 +228,7 @@
     </head>
 
     <body>
-        <slot/>
+        <slot />
     </body>
 
     </html>
@@ -248,14 +271,22 @@
                 height: 20px;
             }
 
-            .box:nth-child(3n+1) { background-color: salmon; }
-            .box:nth-child(3n+2) { background-color: lightseagreen; }
-            .box:nth-child(3n+3) { background-color: rebeccapurple; }
+            .box:nth-child(3n+1) {
+                background-color: salmon;
+            }
+
+            .box:nth-child(3n+2) {
+                background-color: lightseagreen;
+            }
+
+            .box:nth-child(3n+3) {
+                background-color: rebeccapurple;
+            }
         </style>
     </head>
 
     <body>
-    <slot/>
+        <slot />
     </body>
 
     </html>


### PR DESCRIPTION
<img width="760" height="477" alt="image" src="https://github.com/user-attachments/assets/7af3815d-722c-40dd-85cd-e7a13e097fd9" />
<img width="512" height="512" alt="image" src="https://github.com/user-attachments/assets/13a54168-21a6-41aa-8551-72be7ba97c72" />
