### PR TITLE
driver(print): Pass runningPosition to final layout for accurate marg…

### DIFF
--- a/src/vaev-engine/driver/print.cpp
+++ b/src/vaev-engine/driver/print.cpp
@@ -224,7 +224,7 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
 
     auto startOfDocument = Layout::Breakpoint::startOfDocument();
     auto pageInfos = collectBreakPointsAndRunningPositions(runningPosition, paginationContext);
-
+    Layout::RunningPositionMap finalRunningPosition = {};
     for (auto [infos, i] : iter(pageInfos) | Index()) {
         Layout::Input pageLayoutInput{
             .generateFragment = true,
@@ -236,7 +236,8 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
             .breakpointTraverser = {
                 i == 0 ? &startOfDocument : &pageInfos[i - 1].breakpoint,
                 &infos.breakpoint,
-            }
+            },
+            .runningPosition = {&finalRunningPosition}
         };
 
         contentTree.viewport = {
@@ -252,7 +253,7 @@ export Yield<Print::Page> print(Gc::Heap& heap, Gc::Ref<Dom::Document> dom, Prin
             _paintMargins(
                 infos,
                 *pageStack,
-                runningPosition
+                finalRunningPosition
             );
 
         Layout::paint(*output.fragment, *pageStack);

--- a/tests/css/print/running-position-header.xhtml
+++ b/tests/css/print/running-position-header.xhtml
@@ -1,0 +1,72 @@
+<tests>
+  <test name="running-header-fix" flow="paginate" width="210mm" height="297mm" margins="10mm">
+
+    <!-- REFERENCE: manually place a green box at the bottom of each page -->
+    <rendering>
+      <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+          <style>
+            body { margin: 0; }
+            .page {
+              height: 100vh;
+              width: 100%;
+              background: #eee;
+              position: relative;
+            }
+            .box {
+              position: absolute;
+              bottom: 10mm;
+              left: 50%;
+              transform: translateX(-50%);
+              width: 50px;
+              height: 20px;
+              background: green;
+            }
+          </style>
+        </head>
+        <body>
+          <div class="page" style="break-after: page;">
+            <div class="box"></div>
+          </div>
+          <div class="page">
+            <div class="box"></div>
+          </div>
+        </body>
+      </html>
+    </rendering>
+
+    <!-- TEST: use a running header to place the same green box -->
+    <rendering>
+      <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+          <style>
+            @page {
+              @bottom-center {
+                content: element(header);
+              }
+            }
+            body { margin: 0; }
+            .page {
+              height: 100vh;
+              width: 100%;
+              background: #eee;
+            }
+            .header {
+              position: running(header);
+              width: 50px;
+              height: 20px;
+              background: green;
+            }
+          </style>
+        </head>
+        <body>
+          <!-- The running element placed anywhere in the document -->
+          <div class="header"></div>
+          <div class="page" style="break-after: page;"></div>
+          <div class="page"></div>
+        </body>
+      </html>
+    </rendering>
+
+  </test>
+</tests>


### PR DESCRIPTION
…in content.

The final layout pass in print() never set .runningPosition, causing lookForRunningPosition() to early‑return for every box. As a result, _paintMargins() always used the stale map from the discovery pass, leading to incorrect header/footer content when running elements changed between discovery and final render.

This commit adds a fresh RunningPositionMap for the final pass, passes it into Layout::Input, and uses it when painting margins. This ensures margin boxes reflect the actual final layout of each page.