### PR TITLE
vaev-style: Match commas by type in property parsers.

### DIFF
--- a/src/vaev-engine/props/fonts.cpp
+++ b/src/vaev-engine/props/fonts.cpp
@@ -49,7 +49,7 @@ export struct FontFamilyProperty : Property {
                 value.pushBack(try$(parseValue<FontFamily>(c)));
 
                 eatWhitespace(c);
-                c.skip(Css::Token::comma());
+                c.skip(Css::Token::COMMA);
                 eatWhitespace(c);
             }
             return Ok(makeRc<FontFamilyProperty>(self(), std::move(value)));

--- a/src/vaev-engine/props/svg.cpp
+++ b/src/vaev-engine/props/svg.cpp
@@ -362,13 +362,13 @@ export struct SvgViewBoxProperty : Property {
 
             viewBox.minX = try$(parseValue<Number>(c));
 
-            c.skip(Css::Token::comma());
+            c.skip(Css::Token::COMMA);
             viewBox.minY = try$(parseValue<Number>(c));
 
-            c.skip(Css::Token::comma());
+            c.skip(Css::Token::COMMA);
             viewBox.width = try$(parseValue<Number>(c));
 
-            c.skip(Css::Token::comma());
+            c.skip(Css::Token::COMMA);
             viewBox.height = try$(parseValue<Number>(c));
 
             return Ok(makeRc<SvgViewBoxProperty>(self(), Opt{std::move(viewBox)}));


### PR DESCRIPTION
When we `parse` font-families and svg view boxes, we try and skip with the cursor any comma properties to consume the actual data instead of the structure. However, `Css::Token::comma()` is a token factory that returns `{COMMA, data=""}` instead of the actual `COMMA` itself. If a lexer emits a comma with `data=","` `c.skip(Css::Token::comma())` won't match the actual comma.

This causes any multi-value font family list to stop parsing after the first entry. Most of the time that means it falls back to the initial `sans-serif` clause, which affects most stylesheets. For any SVG viewBox calls, any comma-separated value is no longer consumed.

The fix to this is to use the `Css::Token::COMMA` type itself to match on the skip instead of the factory (This concept/structure is already used elsewhere in `values/base.cpp`).