### PR TITLE
vaev-loader: Honor @font-face format() and stop at first usable src.

### DIFF
--- a/src/vaev-engine/loader/loader-impl.cpp
+++ b/src/vaev-engine/loader/loader-impl.cpp
@@ -84,6 +84,20 @@ Async::Task<Rc<Gfx::Fontface>> _loadFontfaceAsync(Http::Client& client, Ref::Url
     co_return Font::loadFontface(mem.seal());
 }
 
+// Formats the engine cannot decode (no woff/woff2/brotli unwrap, no svg/eot
+// font support). Sources carrying one of these format() hints are skipped
+// before fetching; sources with no hint are still tried (we can only know by
+// parsing). See https://www.w3.org/TR/css-fonts-4/#font-format-values
+static bool _isDecodableFontFormat(Str format) {
+    // format() keywords are ASCII case-insensitive (CSS Fonts 4).
+    return not(
+        eqCi(format, "woff"s) or
+        eqCi(format, "woff2"s) or
+        eqCi(format, "svg"s) or
+        eqCi(format, "embedded-opentype"s)
+    );
+}
+
 Async::_Task<Rc<Font::Database>> _loadFontfacesAsync(Http::Client& client, Style::StyleSheetList const& stylesheets, Async::CancellationToken ct) {
     auto fontDatabase = makeRc<Font::Database>(Font::globalDatabase());
     for (auto const& sheet : stylesheets.styleSheets) {
@@ -105,6 +119,11 @@ Async::_Task<Rc<Font::Database>> _loadFontfacesAsync(Http::Client& client, Style
                     break;
                 }
 
+                // Skip sources whose declared format() we cannot decode,
+                // avoiding a fetch + guaranteed parse failure.
+                if (src.format and not _isDecodableFontFormat(src.format.unwrap()))
+                    continue;
+
                 auto fontUrl = src.identifier.unwrap<Ref::Url>();
 
                 auto resolvedUrl = Ref::Url::resolveReference(sheet.href, fontUrl);
@@ -125,6 +144,10 @@ Async::_Task<Rc<Font::Database>> _loadFontfacesAsync(Http::Client& client, Style
                     .face = fontface.unwrap(),
                     .adjust = ff.adjustments(),
                 });
+
+                // First decodable source won; ignore the remaining fallbacks
+                // for this face (matches the local() branch below).
+                break;
             }
         }
     }

--- a/src/vaev-engine/style/fonts.cpp
+++ b/src/vaev-engine/style/fonts.cpp
@@ -132,7 +132,7 @@ export struct SrcFontDescriptor {
                 continue;
             }
 
-            auto fontSrc = fontSrcs.emplaceBack(try$(parseValue<Ref::Url>(c)));
+            auto& fontSrc = fontSrcs.emplaceBack(try$(parseValue<Ref::Url>(c)));
             eatWhitespace(c);
 
             if (not c.ended() and c.peek() == Css::Sst::FUNC and c.peek().prefix == Css::Token::function("format(")) {


### PR DESCRIPTION
When we collect the `src` list of an `@font-face`, each entry carries a `format()` so we know up front whether we can actually use that font before we fetch it. However, the style collection does `auto fontSrc = ...emplaceBack(...)`, which copies the entry that was just emplaced, so the parsed `format` is written to a throwaway and never makes it back into `ff.sources`. On top of that the loader ignores the format hint anyway, fetching and trying to embed every `src` (eot/woff/svg included) and never breaking after the first one that loads.

This means we download and attempt every source in the list instead of stopping at the first one we can use, which wastes fetches (and double-fetches svg). The `src` descriptor is meant to be a prioritized list though: the user agent should walk it and use the first one it can successfully activate, and the `format()` hint is there precisely so we can skip formats we can't decode without ever downloading them.

The fix to this is to capture the emplaced source by reference (`auto&`) so the parsed format survives, skip any `src` whose `format()` we can't decode before fetching it, and break after the first `src` that loads so the rest are only tried as fallbacks when one fails (This behaviour is defined in the CSS Fonts Module Level 4 `src` descriptor).

Ref: https://www.w3.org/TR/css-fonts-4/#src-desc
