### PR TITLE
Support var() substitution on custom properties with an initial value.

### DIFF
--- a/src/vaev-engine/css/lexer.cpp
+++ b/src/vaev-engine/css/lexer.cpp
@@ -36,7 +36,8 @@ namespace Vaev::Css {
     TOKEN(LEFT_PARENTHESIS, leftParenthesis)        /* ( */          \
     TOKEN(RIGHT_PARENTHESIS, rightParenthesis)      /* ) */          \
     TOKEN(COMMENT, comment)                         /* */            \
-    TOKEN(END_OF_FILE, endOfFile)                   /* EOF */
+    TOKEN(END_OF_FILE, endOfFile)                   /* EOF */        \
+    TOKEN(GUARANTEED_INVALID, guaranteedInvalid)    /* unset --foo */
 
 export struct Token {
     enum struct Type {

--- a/src/vaev-engine/css/parser.cpp
+++ b/src/vaev-engine/css/parser.cpp
@@ -56,7 +56,7 @@ export struct Sst {
 
     // https://drafts.csswg.org/css-variables-2/#guaranteed-invalid
     static Sst guaranteedInvalid() {
-        return Token::badString("");
+        return Token::guaranteedInvalid("");
     }
 
     void repr(Io::Emit& e) const {

--- a/src/vaev-engine/props/base.cpp
+++ b/src/vaev-engine/props/base.cpp
@@ -311,6 +311,7 @@ struct DeferredProperty : Property {
     DeferredProperty(Rc<Property::Registration> registration, Css::Content value)
         : Property(registration), _value(value) {}
 
+    // https://www.w3.org/TR/css-variables-1/#substitute-a-var
     static Res<bool> _expandVariable(Cursor<Css::Sst>& c, Map<Symbol, Css::Content> const& env, Css::Content& out, usize depth) {
         if (depth > 32)
             return Error::invalidData("likely dependency cycle in variables");
@@ -330,10 +331,14 @@ struct DeferredProperty : Property {
             return Ok(true);
 
         Symbol varName = Symbol::from(content->token.data);
-        if (auto ref = env.lookup(varName)) {
+
+        if (Opt<Css::Content> ref = env.lookup(varName)) {
             Cursor<Css::Sst> varContent = *ref;
-            try$(_expandContent(varContent, env, out, depth));
-            return Ok(true);
+
+            if (varContent.peek() != Css::Token::GUARANTEED_INVALID) {
+                try$(_expandContent(varContent, env, out, depth));
+                return Ok(true);
+            }
         }
         content.next();
 

--- a/src/vaev-engine/style/origin.cpp
+++ b/src/vaev-engine/style/origin.cpp
@@ -14,6 +14,7 @@ export enum struct Origin : u8 {
     AUTHOR_PRESENTATIONAL_HINT,
     AUTHOR,
     INLINE, //< Declarations from style attributes
+    _LEN,
 };
 
 export std::strong_ordering operator<=>(Origin a, Origin b) {

--- a/src/vaev-engine/values/sizing.cpp
+++ b/src/vaev-engine/values/sizing.cpp
@@ -22,6 +22,7 @@ namespace Vaev {
 export enum struct BoxSizing : u8 {
     CONTENT_BOX,
     BORDER_BOX,
+    _LEN,
 };
 
 // MARK: FitContent

--- a/tests/css/custom-property.xhtml
+++ b/tests/css/custom-property.xhtml
@@ -98,4 +98,40 @@
 </rendering>
 </test>
 
+
+<test name="custom-properties-initial-value">
+<container>
+    <html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+
+    <head>
+        <style>
+            div {
+                width: 100px;
+                height: 100px;
+                border-radius: 7px;
+            }
+
+            unused {
+                --foo: cornflowerblue;
+            }
+        </style>
+    </head>
+
+    <body>
+    <slot/>
+    </body>
+
+    </html>
+</container>
+
+<rendering>
+    <div style="background:lightsalmon;"></div>
+</rendering>
+
+<rendering help="variable set to initial value with fallback">
+    <div style="background: var(--foo, lightsalmon);"></div>
+</rendering>
+
+</test>
+
 </tests>


### PR DESCRIPTION
Fixes the link colors that used to be black on reports:

<img width="749" height="119" alt="image" src="https://github.com/user-attachments/assets/e3cfd47a-520d-4aca-83c7-71a1b22bae45" />
