### PR TITLE
vaev-layout: Preserve and trim inter-inline whitespace.

### DIFF
--- a/src/vaev-engine/layout/base/box.cpp
+++ b/src/vaev-engine/layout/base/box.cpp
@@ -26,6 +26,9 @@ struct Box : Meta::NoCopy {
     Opt<Rc<FormatingContext>> formatingContext = NONE;
     Opt<Dom::OriginatingElement> origin;
 
+    // White-space phase 2: collapsed space held until following line content materializes it.
+    bool pendingCollapsibleSpace = false;
+
     static Box fromInterruptedInlineBox(Box const& inlineBox) {
         auto oldProse = inlineBox.content.unwrap<Rc<Gfx::Prose>>();
         Rc<Gfx::Prose> prose = makeRc<Gfx::Prose>(oldProse->_style, oldProse->_currentSpan);
@@ -47,8 +50,11 @@ struct Box : Meta::NoCopy {
     }
 
     void add(Box&& box) {
-        if (auto it = content.is<Rc<Gfx::Prose>>())
+        if (auto it = content.is<Rc<Gfx::Prose>>()) {
             (*it)->append(Gfx::Prose::StrutCell{_children.len()});
+            // Atomic inline box ends the line's pending space; drop it to keep boxes gapless.
+            pendingCollapsibleSpace = false;
+        }
         _children.pushBack(std::move(box));
     }
 

--- a/src/vaev-engine/layout/builder/mod.cpp
+++ b/src/vaev-engine/layout/builder/mod.cpp
@@ -117,6 +117,11 @@ void _appendTextToInlineBox(Io::SScan scan, Rc<Style::ComputedValues> parentStyl
         auto prose = rootInlineBox.content.unwrap<Rc<Gfx::Prose>>();
 
         if (not isAsciiSpace(rune)) {
+            // A glyph follows the deferred space, so materialize it (e.g. "5.00 Units").
+            if (rootInlineBox.pendingCollapsibleSpace) {
+                prose->append(' ');
+                rootInlineBox.pendingCollapsibleSpace = false;
+            }
             _transformAndAppendRuneToProse(
                 prose,
                 rune,
@@ -148,10 +153,13 @@ void _appendTextToInlineBox(Io::SScan scan, Rc<Style::ComputedValues> parentStyl
             // https://www.w3.org/TR/css-text-3/#valdef-white-space-pre-line
             // Collapsible segment breaks are transformed for rendering according to the segment
             // break transformation rules.
-            if (whitespace == WhiteSpace::PRE_LINE and visitedSegmentBreak)
+            if (whitespace == WhiteSpace::PRE_LINE and visitedSegmentBreak) {
+                // Forced break ends the line: drop the deferred space instead of leaking it.
+                rootInlineBox.pendingCollapsibleSpace = false;
                 prose->append('\n');
-            else
-                prose->append(' ');
+            } else
+                // Defer the space; emitted only if a glyph follows, else dropped at line end.
+                rootInlineBox.pendingCollapsibleSpace = true;
         } else if (whitespace == WhiteSpace::PRE) {
             prose->append(rune);
         } else {
@@ -329,10 +337,12 @@ static void _buildText(BuilderContext bc, Str text, Rc<Style::ComputedValues> pa
     // (i.e. characters that can be affected by the white-space property) it is instead not rendered
     // (just as if its text nodes were display:none).
 
+    // In a block context, keep whitespace only between inline-level boxes (active line),
+    // not between blocks or at line start, so "5.00 Units" survives but block gaps don't.
     bool shouldSkipWhitespace =
         bc.from == BuilderContext::From::TABLE or
         bc.from == BuilderContext::From::FLEX or
-        bc.from == BuilderContext::From::BLOCK;
+        (bc.from == BuilderContext::From::BLOCK and not bc.rootInlineBox().isActive());
 
     bool addedNonWhitespace = _buildText(text, parentStyle, bc.rootInlineBox(), shouldSkipWhitespace);
 


### PR DESCRIPTION
When we build text in a block formatting context, `_buildText` skips any whitespace-only text node outright. However, whitespace between two inline-level boxes is not structural: it collapses to a single preserved space, so dropping the node loses the gap between adjacent spans. Such a node should only be skipped when there is no active inline content on the line (leading or inter-block whitespace).

For example, in Odoo's sale order report the product quantity is rendered as two [adjacent spans](https://github.com/odoo/odoo/blob/13c182c6d37c420dfa44248fbe83d8c0f1de5563/addons/sale/report/ir_actions_report_templates.xml#L250-L251), `<span>5.00</span>` and `<span>Units</span>`. The whitespace between them is dropped, so the line renders as `5.00Units` instead of `5.00 Units`.

Letting it through on its own would then leak trailing spaces, because the builder implements only the leading half of white-space phase 2 and never trims the end of a line. The collapsed space has to survive long enough to be either emitted or dropped depending on what follows it.

The fix to this is a deferred space: a collapsed space is held on the root inline box and materialized only once a following glyph is appended, so it is dropped at end of line. Anything else that ends the line's run of pending whitespace consumes it the same way, so the space is also dropped before an atomic inline box and across a forced (pre-line) break (this is the trailing half of white-space phase 2).

Ref: https://www.w3.org/TR/css-text-3/#white-space-phase-2