### PR TITLE
freebsd: Add FreeBSD 15.1 build support

### DIFF
--- a/project.json
+++ b/project.json
@@ -6,8 +6,8 @@
     "description": "An experimental document-generation tool",
     "externs": {
         "skift/karm": {
-            "git": "https://codeberg.org/skift/karm.git",
-            "tag": "main"
+            "git": "https://github.com/satriani-vai/karm.git",
+            "tag": "freebsd-support"
         },
         "cute-engineering/cat": {
             "git": "https://codeberg.org/cute-engineering/cat.git",

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,29 @@ paper-muncher index.html -o output.pdf
 paper-muncher --help
 ```
 
+## FreeBSD 15.1+
+
+Paper Muncher builds and runs natively on FreeBSD 15.1 (amd64) with Clang 19. Use this fork which provides the required karm patches:
+
+```sh
+# Install build dependencies
+pkg install python3 py311-pip git pkgconf libunwind
+
+# Install cutekit
+pip install cutekit
+
+# Clone the FreeBSD fork
+git clone https://github.com/satriani-vai/paper-muncher.git
+cd paper-muncher
+git checkout freebsd-support
+
+# Build
+CUTEKIT_ALLOW_ROOT=1 ./ck build
+CUTEKIT_ALLOW_ROOT=1 ./ck run paper-muncher -- input.md -o output.pdf
+```
+
+The fork pulls `karm` from `satriani-vai/karm:freebsd-support` which includes the necessary FreeBSD portability patches (kevent/async emulation, POSIX headers, sandbox stub).
+
 ## Contributing
 
 We welcome contributions to the Paper Muncher project! If you have ideas, suggestions, or bug reports, please open an issue on our GitHub repository. If you're interested in contributing code, please fork the repository and submit a pull request.


### PR DESCRIPTION
## Summary

Adds native FreeBSD 15.1 (amd64) build support for paper-muncher.

## Changes

- **`project.json`**: Points the `skift/karm` extern to `satriani-vai/karm:freebsd-support` which contains the required FreeBSD portability patches.
- **`readme.md`**: Adds FreeBSD build instructions.

## Background

paper-muncher depends on `skift/karm` (hosted on Codeberg) for its system abstraction layer. karm did not support FreeBSD out of the box. The patches in the fork include:

- kevent64 emulation using native FreeBSD kevent
- Userspace tracking of regular-file events for kevent compatibility
- POSIX header fixes (`<libutil.h>` instead of `<pty.h>`)
- Sandbox stub (no seccomp/landlock on FreeBSD)
- Linking against `libunwind` and `libutil` from `/usr/local`

## Testing

Verified on FreeBSD 15.1-RELEASE (amd64) with Clang 19.1.7:
- Full build completes successfully (1520 targets)
- 443/444 tests pass (1 failure is an upstream macOS/kevent issue, not FreeBSD-specific)
- Markdown → PDF conversion works
- HTML → PDF conversion works
- SVG → PDF/BMP/QOI conversion works

## Upstream Path

The long-term fix is to upstream the karm patches to `codeberg.org/skift/karm`. This PR provides an immediate working solution for FreeBSD users and documents the required changes for the karm maintainers.

## Build Instructions (FreeBSD)

```sh
pkg install python3 py311-pip git pkgconf libunwind
pip install cutekit
git clone https://github.com/satriani-vai/paper-muncher.git
cd paper-muncher
git checkout freebsd-support
CUTEKIT_ALLOW_ROOT=1 ./ck build
CUTEKIT_ALLOW_ROOT=1 ./ck run paper-muncher -- input.md -o output.pdf
```