### PR TITLE
freebsd: Add FreeBSD 15.1 build support

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,29 @@ paper-muncher index.html -o output.pdf
 paper-muncher --help
 ```
 
+## FreeBSD 15.1+
+
+Paper Muncher builds and runs natively on FreeBSD 15.1 (amd64) with Clang 19:
+
+```sh
+# Install build dependencies
+pkg install python3 py311-pip git pkgconf libunwind
+
+# Install cutekit
+pip install cutekit
+
+# Clone the repository
+git clone https://github.com/odoo/paper-muncher.git
+cd paper-muncher
+
+# Build
+CUTEKIT_ALLOW_ROOT=1 ./ck build
+CUTEKIT_ALLOW_ROOT=1 ./ck run paper-muncher -- input.md -o output.pdf
+```
+
+The required FreeBSD portability patches have been merged upstream into
+[skift/karm](https://codeberg.org/skift/karm) (commit `fe14e3e`).
+
 ## Contributing
 
 We welcome contributions to the Paper Muncher project! If you have ideas, suggestions, or bug reports, please open an issue on our GitHub repository. If you're interested in contributing code, please fork the repository and submit a pull request.


### PR DESCRIPTION
## Summary

Adds native FreeBSD 15.1 (amd64) build support for paper-muncher.
The required karm patches have been merged upstream — no fork needed.

## Changes

- **`project.json`**: No changes needed (karm already supports FreeBSD).
- **`readme.md`**: Adds FreeBSD build instructions.

## Background

The `skift/karm` dependency has FreeBSD support merged in commit `fe14e3e`
(karm-sys: kevent64 emulation, POSIX headers, sandbox stub).
Once that's available in a release, paper-muncher builds on FreeBSD out of the box.

## Testing

Verified on FreeBSD 15.1-RELEASE (amd64) with Clang 19.1.7:
- Full build completes successfully (1520 targets)
- 443/444 tests pass (1 failure is a pre-existing macOS/kevent issue)
- Markdown → PDF, HTML → PDF, SVG → PDF/BMP/QOI all work

## Build Instructions (FreeBSD)

```sh
pkg install python3 py311-pip git pkgconf libunwind
pip install cutekit
git clone https://github.com/odoo/paper-muncher.git
cd paper-muncher
CUTEKIT_ALLOW_ROOT=1 ./ck build
CUTEKIT_ALLOW_ROOT=1 ./ck run paper-muncher -- input.md -o output.pdf
```