### PR TITLE
vaev-style: Remove virtual flags functions.

### DIFF
--- a/src/vaev-engine/props/background.cpp
+++ b/src/vaev-engine/props/background.cpp
@@ -210,12 +210,11 @@ export struct BackgroundRepeatProperty : Property {
 // https://www.w3.org/TR/CSS22/colors.html#x10
 export struct BackgroundProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BACKGROUND;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -255,12 +254,11 @@ export struct BackgroundProperty : Property {
 // https://www.w3.org/TR/CSS22/colors.html#propdef-color
 export struct ColorProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::COLOR;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/base.cpp
+++ b/src/vaev-engine/props/base.cpp
@@ -133,6 +133,10 @@ export struct Property : Meta::NoCopy {
     // https://drafts.css-houdini.org/css-properties-values-api/#custom-property-registration
     struct Registration : Meta::NoCopy {
         Opt<Weak<Registration>> _self;
+        Flags<Options> flags = {};
+
+        Registration(Flags<Options> flags = {})
+            : flags(flags) {}
 
         Rc<Registration> self() const {
             return _self
@@ -157,10 +161,6 @@ export struct Property : Meta::NoCopy {
             return {};
         }
 
-        virtual Flags<Options> flags() const {
-            return {};
-        }
-
         // https://drafts.csswg.org/css-cascade/#initial-value
         virtual Rc<Property> initial() const = 0;
 
@@ -170,7 +170,7 @@ export struct Property : Meta::NoCopy {
             // NOTE: This is the slow fallback path for properties that are not
             //       commonly inherited. Any property marked with the INHERITED
             //       flag should override this method with a faster implementation.
-            if (flags().has(INHERITED))
+            if (flags.has(INHERITED))
                 logFatal("property {:#} marked as INHERITED is using the slow fallback path. override inherit()!", name());
 
             // NOTE: Since we are copying computed values, we don't expect much new computation to happen
@@ -227,11 +227,11 @@ export struct Property : Meta::NoCopy {
     }
 
     bool isCustomProperty() const {
-        return registration->flags().has(CUSTOM_PROPERTY);
+        return registration->flags.has(CUSTOM_PROPERTY);
     }
 
     bool isShorthandProperty() const {
-        return registration->flags().has(SHORTHAND_PROPERTY);
+        return registration->flags.has(SHORTHAND_PROPERTY);
     }
 
     virtual bool isDefaulted() const {
@@ -240,7 +240,7 @@ export struct Property : Meta::NoCopy {
 
     /// Determines whether this property instance represents a parsing failure or an unrecognized CSS declaration.
     virtual bool isBogusProperty() const {
-        return registration->flags().has(BOGUS_REGISTRATION);
+        return registration->flags.has(BOGUS_REGISTRATION);
     }
 
     bool operator==(Property const& other) const {
@@ -259,19 +259,12 @@ struct CustomProperty : Property {
     struct Registration : Property::Registration {
         Symbol _name;
 
-        Registration(Symbol name) : _name(name) {}
+        Registration(Symbol name)
+            : Property::Registration({INHERITED, CUSTOM_PROPERTY, ALL_EXCLUDED, BULK_INHERITED}),
+              _name(name) {}
 
         Symbol name() const override {
             return _name;
-        }
-
-        Flags<Options> flags() const override {
-            return {
-                INHERITED,
-                CUSTOM_PROPERTY,
-                ALL_EXCLUDED,
-                BULK_INHERITED,
-            };
         }
 
         ComputationPhase computationPhase() const override {
@@ -510,7 +503,7 @@ struct DefaultedProperty : Property {
             // The unset CSS-wide keyword acts as either inherit or initial,
             // depending on whether the property is inherited or not.
             // https://drafts.csswg.org/css-cascade/#inherit-initial
-            if (registration->flags().has(INHERITED))
+            if (registration->flags.has(INHERITED))
                 return registration->load(parent)->expandShorthand(registry, parent, child);
 
             return registration->initial()->expandShorthand(registry, parent, child);
@@ -537,7 +530,7 @@ struct DefaultedProperty : Property {
             // The unset CSS-wide keyword acts as either inherit or initial,
             // depending on whether the property is inherited or not.
             // https://drafts.csswg.org/css-cascade/#inherit-initial
-            if (registration->flags().has(INHERITED))
+            if (registration->flags.has(INHERITED))
                 registration->load(parent)->apply(parent, c, cx);
             else
                 registration->initial()->apply(parent, c, cx);
@@ -565,12 +558,9 @@ struct BogusProperty : Property {
     struct Registration : Property::Registration {
         Symbol _name;
 
-        Registration(Symbol name)
-            : _name(name) {}
-
-        Flags<Options> flags() const override {
-            return {BOGUS_REGISTRATION};
-        }
+        Registration(Symbol const name)
+            : Property::Registration(BOGUS_REGISTRATION),
+              _name(name) {}
 
         Symbol name() const override {
             return _name;
@@ -638,7 +628,7 @@ export struct RegisteredPropertySet {
         // Registrations are append-only and property names must be unique.
         assert$(not _registrations.lookup(propertyName));
 
-        auto registrationFlags = registration->flags();
+        auto registrationFlags = registration->flags;
 
         if (registrationFlags.has(Property::PRESENTATION_ATTRIBUTE))
             _presentationAttributes.put(propertyName, registration);
@@ -703,7 +693,7 @@ export struct RegisteredPropertySet {
         if (not _memoInitialComputedValues) {
             auto initial = makeRc<ComputedValues>();
             for (auto& [_, registration] : registrations().iterItems())
-                if (not registration->flags().has(Property::SHORTHAND_PROPERTY))
+                if (not registration->flags.has(Property::SHORTHAND_PROPERTY))
                     registration->initial()->apply(*initial, *initial, cx);
             _memoInitialComputedValues = Some(initial);
         }
@@ -770,7 +760,7 @@ export struct RegisteredPropertySet {
         Cursor cursor = content;
 
         auto registration = try$(resolveRegistration(propertyName, options));
-        if (registration->flags().has(Property::BOGUS_REGISTRATION))
+        if (registration->flags.has(Property::BOGUS_REGISTRATION))
             return Ok(makeRc<BogusProperty>(registration, content, Error::invalidData("unknow property")));
 
         eatWhitespace(cursor);

--- a/src/vaev-engine/props/baseline.cpp
+++ b/src/vaev-engine/props/baseline.cpp
@@ -16,12 +16,11 @@ namespace Vaev::Style {
 // https://drafts.csswg.org/css-inline/#line-height-property
 export struct LineHeightProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::LINE_HEIGHT;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -200,12 +199,11 @@ export struct VerticalAlignProperty : Property {
     };
 
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::VERTICAL_ALIGN;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/border.cpp
+++ b/src/vaev-engine/props/border.cpp
@@ -153,12 +153,11 @@ export struct BorderLeftColorProperty : Property {
 
 export struct BorderColorProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER_COLOR;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -342,12 +341,11 @@ export struct BorderBottomStyleProperty : Property {
 
 export struct BorderStyleProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER_STYLE;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -738,12 +736,11 @@ export struct BorderRadiusProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-shorthands
 export struct BorderTopProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER_TOP;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -802,12 +799,11 @@ export struct BorderTopProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-shorthands
 export struct BorderRightProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER_RIGHT;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -844,12 +840,11 @@ export struct BorderRightProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-shorthands
 export struct BorderBottomProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER_BOTTOM;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -886,12 +881,11 @@ export struct BorderBottomProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-shorthands
 export struct BorderLeftProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER_LEFT;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -928,12 +922,11 @@ export struct BorderLeftProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-shorthands
 export struct BorderProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -982,12 +975,11 @@ export struct BorderProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-width
 export struct BorderWidthProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::BORDER_WIDTH;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -1035,12 +1027,11 @@ export struct BorderWidthProperty : Property {
 // https://www.w3.org/TR/CSS22/tables.html#propdef-border-collapse
 export struct BorderCollapseProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::BORDER_COLLAPSE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -1077,12 +1068,11 @@ export struct BorderCollapseProperty : Property {
 // https://www.w3.org/TR/CSS22/tables.html#propdef-border-spacing
 export struct BorderSpacingProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::BORDER_SPACING;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/flex.cpp
+++ b/src/vaev-engine/props/flex.cpp
@@ -188,12 +188,11 @@ export struct FlexWrapProperty : Property {
 // https://www.w3.org/TR/css-flexbox-1/#propdef-flex-flow
 export struct FlexFlowProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::FLEX_FLOW;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -252,12 +251,11 @@ export struct FlexFlowProperty : Property {
 // https://www.w3.org/TR/css-flexbox-1/#propdef-flex
 export struct FlexProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::FLEX;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/fonts.cpp
+++ b/src/vaev-engine/props/fonts.cpp
@@ -18,12 +18,11 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/css-fonts-4/#font-family-prop
 export struct FontFamilyProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::FONT_FAMILY;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         ComputationPhase computationPhase() const override {
@@ -73,12 +72,11 @@ export struct FontFamilyProperty : Property {
 // https://www.w3.org/TR/css-fonts-4/#font-weight-prop
 export struct FontWeightProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::FONT_WEIGHT;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         ComputationPhase computationPhase() const override {
@@ -119,6 +117,9 @@ export struct FontWeightProperty : Property {
 // https://www.w3.org/TR/css-fonts-4/#font-width-prop
 export struct FontWidthProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::FONT_WIDTH;
         }
@@ -126,10 +127,6 @@ export struct FontWidthProperty : Property {
         // https://drafts.csswg.org/css-fonts/#font-stretch-prop
         Vec<Symbol> legacyAlias() const override {
             return {"font-stretch"_sym};
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         ComputationPhase computationPhase() const override {
@@ -170,12 +167,11 @@ export struct FontWidthProperty : Property {
 // https://www.w3.org/TR/css-fonts-4/#font-style-prop
 export struct FontStyleProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::FONT_STYLE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         ComputationPhase computationPhase() const override {
@@ -216,12 +212,11 @@ export struct FontStyleProperty : Property {
 // https://www.w3.org/TR/css-fonts-4/#font-size-prop
 export struct FontSizeProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::FONT_SIZE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         ComputationPhase computationPhase() const override {
@@ -280,12 +275,11 @@ export struct FontProperty : Property {
     };
 
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::FONT;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/list.cpp
+++ b/src/vaev-engine/props/list.cpp
@@ -11,12 +11,11 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/css-lists-3/#propdef-list-style-image
 struct ListStyleImageProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::LIST_STYLE_IMAGE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -54,12 +53,11 @@ struct ListStyleImageProperty : Property {
 // https://www.w3.org/TR/css-lists-3/#propdef-list-style-type
 struct ListStyleTypeProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::LIST_STYLE_TYPE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -97,12 +95,11 @@ struct ListStyleTypeProperty : Property {
 // https://www.w3.org/TR/css-lists-3/#list-style-position-property
 struct ListStylePositionProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::LIST_STYLE_POSITION;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -150,12 +147,11 @@ struct ListStyleProperty : Property {
     };
 
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::LIST_STYLE;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {
@@ -227,12 +223,11 @@ struct ListStyleProperty : Property {
 // https://www.w3.org/TR/css-lists-3/#propdef-marker-side
 struct MarkerSideProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::MARKER_SIDE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         void inherit(ComputedValues const& parent, ComputedValues& child) const override {

--- a/src/vaev-engine/props/margin.cpp
+++ b/src/vaev-engine/props/margin.cpp
@@ -162,12 +162,11 @@ export struct MarginProperty : Property {
     using Value = Math::Insets<MarginTopProperty::Value>;
 
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::MARGIN;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/outline.cpp
+++ b/src/vaev-engine/props/outline.cpp
@@ -175,12 +175,11 @@ export struct OutlineOffsetProperty : Property {
 // https://drafts.csswg.org/css-ui/#outline
 export struct OutlineProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::OUTLINE;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/overflow.cpp
+++ b/src/vaev-engine/props/overflow.cpp
@@ -154,12 +154,11 @@ export struct OverflowInlineProperty : Property {
 // https://www.w3.org/TR/css-overflow-3/#propdef-overflow
 export struct OverflowProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::OVERFLOW;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/padding.cpp
+++ b/src/vaev-engine/props/padding.cpp
@@ -217,12 +217,11 @@ export struct PaddingInlineEndProperty : Property {
 
 export struct PaddingProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(SHORTHAND_PROPERTY) {}
+
         Symbol name() const override {
             return Properties::PADDING;
-        }
-
-        Flags<Options> flags() const override {
-            return {SHORTHAND_PROPERTY};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/sizing.cpp
+++ b/src/vaev-engine/props/sizing.cpp
@@ -61,12 +61,11 @@ export struct BoxSizingProperty : Property {
 // https://www.w3.org/TR/css-sizing-3/#propdef-width
 export struct WidthProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::WIDTH;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -106,12 +105,11 @@ export struct WidthProperty : Property {
 
 export struct HeightProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::HEIGHT;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/svg.cpp
+++ b/src/vaev-engine/props/svg.cpp
@@ -18,12 +18,11 @@ namespace Vaev::Style {
 // https://svgwg.org/svg2-draft/geometry.html#XProperty
 export struct SvgXProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::X;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -60,12 +59,11 @@ export struct SvgXProperty : Property {
 // https://svgwg.org/svg2-draft/geometry.html#YProperty
 export struct SvgYProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::Y;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -102,12 +100,11 @@ export struct SvgYProperty : Property {
 // https://svgwg.org/svg2-draft/geometry.html#CXProperty
 export struct SvgCXProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::CX;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -144,12 +141,11 @@ export struct SvgCXProperty : Property {
 // https://svgwg.org/svg2-draft/geometry.html#CYProperty
 export struct SvgCYProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::CY;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -186,12 +182,11 @@ export struct SvgCYProperty : Property {
 // https://svgwg.org/svg2-draft/geometry.html#RProperty
 export struct SvgRProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::R;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -228,12 +223,11 @@ export struct SvgRProperty : Property {
 // https://svgwg.org/svg2-draft/painting.html#FillProperty
 export struct SvgFillProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
+
         Symbol name() const override {
             return Properties::FILL;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE, INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -275,12 +269,11 @@ export struct SvgFillProperty : Property {
 // https://svgwg.org/svg2-draft/paths.html#TheDProperty
 export struct SvgDProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::D;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -341,12 +334,11 @@ export struct SvgDProperty : Property {
 // https://svgwg.org/svg2-draft/coords.html#ViewBoxAttribute
 export struct SvgViewBoxProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::VIEWBOX;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -392,12 +384,11 @@ export struct SvgViewBoxProperty : Property {
 // https://svgwg.org/svg2-draft/painting.html#SpecifyingStrokePaint
 export struct SvgStrokeProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
+
         Symbol name() const override {
             return Properties::STROKE;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE, INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -439,12 +430,11 @@ export struct SvgStrokeProperty : Property {
 // https://svgwg.org/svg2-draft/painting.html#StrokeOpacity
 export struct SvgStrokeOpacityProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::STROKE_OPACITY;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -491,12 +481,11 @@ export struct SvgStrokeOpacityProperty : Property {
 // https://svgwg.org/svg2-draft/painting.html#FillOpacity
 export struct FillOpacityProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
+
         Symbol name() const override {
             return Properties::FILL_OPACITY;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE, INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -543,12 +532,11 @@ export struct FillOpacityProperty : Property {
 // https://svgwg.org/svg2-draft/painting.html#StrokeWidth
 export struct StrokeWidthProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
+
         Symbol name() const override {
             return Properties::STROKE_WIDTH;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE, INHERITED};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/table.cpp
+++ b/src/vaev-engine/props/table.cpp
@@ -50,12 +50,11 @@ export struct TableLayoutProperty : Property {
 // https://www.w3.org/TR/CSS21/tables.html#caption-position
 export struct CaptionSideProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::CAPTION_SIDE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/text.cpp
+++ b/src/vaev-engine/props/text.cpp
@@ -20,12 +20,11 @@ namespace Vaev::Style {
 
 export struct TextAlignProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::TEXT_ALIGN;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -85,12 +84,11 @@ export struct TextAlignProperty : Property {
 
 export struct TextTransformProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::TEXT_TRANSFORM;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {
@@ -142,12 +140,11 @@ export struct TextTransformProperty : Property {
 
 export struct WhiteSpaceProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(INHERITED) {}
+
         Symbol name() const override {
             return Properties::WHITE_SPACE;
-        }
-
-        Flags<Options> flags() const override {
-            return {INHERITED};
         }
 
         Rc<Property> initial() const override {

--- a/src/vaev-engine/props/transform.cpp
+++ b/src/vaev-engine/props/transform.cpp
@@ -19,12 +19,11 @@ namespace Vaev::Style {
 // https://drafts.csswg.org/css-transforms/#transform-origin-property
 export struct TransformOriginProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::TRANSFORM_ORIGIN;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {
@@ -97,12 +96,11 @@ export struct TransformBoxProperty : Property {
 // https://drafts.csswg.org/css-transforms/#propdef-transform
 export struct TransformProperty : Property {
     struct Registration : Property::Registration {
+        Registration()
+            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
+
         Symbol name() const override {
             return Properties::TRANSFORM;
-        }
-
-        Flags<Options> flags() const override {
-            return {PRESENTATION_ATTRIBUTE};
         }
 
         Rc<Property> initial() const override {


### PR DESCRIPTION
Replace virtual property registration `flags()` methods with constructor-initialized flag data.

### Benchmark

with `hyperfine --warmup 1 --runs 5` on 2000 entry ledger

Before:
```
Time (mean ± σ):     23.240 s ±  0.643 s    [User: 23.097 s, System: 0.131 s]
Range (min … max):   22.868 s … 24.384 s    5 runs
```

After:
```
Time (mean ± σ):     19.682 s ±  0.076 s    [User: 19.554 s, System: 0.118 s]
Range (min … max):   19.568 s … 19.773 s    5 runs
```