### PR TITLE
vaev-style: Remove virtual name functions.

### DIFF
--- a/src/vaev-engine/props/align.cpp
+++ b/src/vaev-engine/props/align.cpp
@@ -19,9 +19,7 @@ namespace Vaev::Style {
 // https://drafts.csswg.org/css-align-3/#propdef-align-content
 export struct AlignContentProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::ALIGN_CONTENT;
-        }
+        Registration() : Property::Registration(Properties::ALIGN_CONTENT) {}
 
         Rc<Property> initial() const override {
             return makeRc<AlignContentProperty>(self(), Align::Keywords::STRETCH);
@@ -53,9 +51,7 @@ export struct AlignContentProperty : Property {
 // https://drafts.csswg.org/css-align-3/#propdef-justify-content
 export struct JustifyContentProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::JUSTIFY_CONTENT;
-        }
+        Registration() : Property::Registration(Properties::JUSTIFY_CONTENT) {}
 
         Rc<Property> initial() const override {
             return makeRc<JustifyContentProperty>(self(), Align::Keywords::FLEX_START);
@@ -87,9 +83,7 @@ export struct JustifyContentProperty : Property {
 // https://drafts.csswg.org/css-align-3/#propdef-justify-self
 export struct JustifySelfProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::JUSTIFY_SELF;
-        }
+        Registration() : Property::Registration(Properties::JUSTIFY_SELF) {}
 
         Rc<Property> initial() const override {
             return makeRc<JustifySelfProperty>(self(), Align::Keywords::AUTO);
@@ -121,9 +115,7 @@ export struct JustifySelfProperty : Property {
 // https://drafts.csswg.org/css-align-3/#propdef-align-self
 export struct AlignSelfProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::ALIGN_SELF;
-        }
+        Registration() : Property::Registration(Properties::ALIGN_SELF) {}
 
         Rc<Property> initial() const override {
             return makeRc<AlignSelfProperty>(self(), Align::Keywords::AUTO);
@@ -155,9 +147,7 @@ export struct AlignSelfProperty : Property {
 // https://drafts.csswg.org/css-align-3/#propdef-justify-items
 export struct JustifyItemsProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::JUSTIFY_ITEMS;
-        }
+        Registration() : Property::Registration(Properties::JUSTIFY_ITEMS) {}
 
         Rc<Property> initial() const override {
             return makeRc<JustifyItemsProperty>(self(), Align::LEGACY);
@@ -189,9 +179,7 @@ export struct JustifyItemsProperty : Property {
 // https://drafts.csswg.org/css-align-3/#propdef-align-items
 export struct AlignItemsProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::ALIGN_ITEMS;
-        }
+        Registration() : Property::Registration(Properties::ALIGN_ITEMS) {}
 
         Rc<Property> initial() const override {
             return makeRc<AlignItemsProperty>(self(), Align::Keywords::STRETCH);
@@ -223,9 +211,7 @@ export struct AlignItemsProperty : Property {
 // https://drafts.csswg.org/css-align-3/#column-row-gap
 export struct RowGapProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::ROW_GAP;
-        }
+        Registration() : Property::Registration(Properties::ROW_GAP) {}
 
         // https://drafts.csswg.org/css-align-3/#gap-legacy
         Vec<Symbol> legacyAlias() const override {
@@ -262,9 +248,7 @@ export struct RowGapProperty : Property {
 // https://drafts.csswg.org/css-align-3/#column-row-gap
 export struct ColumnGapProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::COLUMN_GAP;
-        }
+        Registration() : Property::Registration(Properties::COLUMN_GAP) {}
 
         // https://drafts.csswg.org/css-align-3/#gap-legacy
         Vec<Symbol> legacyAlias() const override {
@@ -300,9 +284,7 @@ export struct ColumnGapProperty : Property {
 
 export struct GapProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::GAP;
-        }
+        Registration() : Property::Registration(Properties::GAP) {}
 
         // https://drafts.csswg.org/css-align-3/#gap-legacy
         Vec<Symbol> legacyAlias() const override {

--- a/src/vaev-engine/props/background.cpp
+++ b/src/vaev-engine/props/background.cpp
@@ -21,9 +21,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/CSS22/colors.html#propdef-background-color
 export struct BackgroundColorProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BACKGROUND_COLOR;
-        }
+        Registration() : Property::Registration(Properties::BACKGROUND_COLOR) {}
 
         Rc<Property> initial() const override {
             return makeRc<BackgroundColorProperty>(self(), TRANSPARENT);
@@ -57,9 +55,7 @@ export struct BackgroundColorProperty : Property {
 // https://www.w3.org/TR/CSS22/colors.html#propdef-background-attachment
 export struct BackgroundAttachmentProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BACKGROUND_ATTACHMENT;
-        }
+        Registration() : Property::Registration(Properties::BACKGROUND_ATTACHMENT) {}
 
         Rc<Property> initial() const override {
             return makeRc<BackgroundAttachmentProperty>(self(), Vec<BackgroundAttachment>{Keywords::SCROLL});
@@ -104,9 +100,7 @@ export struct BackgroundAttachmentProperty : Property {
 // https://www.w3.org/TR/CSS22/colors.html#propdef-background-image
 export struct BackgroundImageProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BACKGROUND_IMAGE;
-        }
+        Registration() : Property::Registration(Properties::BACKGROUND_IMAGE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BackgroundImageProperty>(self(), Vec<Image>{});
@@ -139,9 +133,7 @@ export struct BackgroundImageProperty : Property {
 // https://www.w3.org/TR/CSS22/colors.html#propdef-background-position
 export struct BackgroundPositionProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BACKGROUND_POSITION;
-        }
+        Registration() : Property::Registration(Properties::BACKGROUND_POSITION) {}
 
         Rc<Property> initial() const override {
             return makeRc<BackgroundPositionProperty>(self(), Vec<BackgroundPosition>{});
@@ -174,9 +166,7 @@ export struct BackgroundPositionProperty : Property {
 // https://www.w3.org/TR/CSS22/colors.html#propdef-background-repeat
 export struct BackgroundRepeatProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BACKGROUND_REPEAT;
-        }
+        Registration() : Property::Registration(Properties::BACKGROUND_REPEAT) {}
 
         Rc<Property> initial() const override {
             return makeRc<BackgroundRepeatProperty>(self(), Vec<BackgroundRepeat>{BackgroundRepeat::REPEAT});
@@ -211,11 +201,7 @@ export struct BackgroundRepeatProperty : Property {
 export struct BackgroundProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BACKGROUND;
-        }
+            : Property::Registration(Properties::BACKGROUND, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BackgroundProperty>(self(), SpecifiedBackground{TRANSPARENT});
@@ -255,11 +241,7 @@ export struct BackgroundProperty : Property {
 export struct ColorProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::COLOR;
-        }
+            : Property::Registration(Properties::COLOR, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<ColorProperty>(self(), BLACK);

--- a/src/vaev-engine/props/base.cpp
+++ b/src/vaev-engine/props/base.cpp
@@ -133,10 +133,11 @@ export struct Property : Meta::NoCopy {
     // https://drafts.css-houdini.org/css-properties-values-api/#custom-property-registration
     struct Registration : Meta::NoCopy {
         Opt<Weak<Registration>> _self;
+        Symbol name;
         Flags<Options> flags = {};
 
-        Registration(Flags<Options> flags = {})
-            : flags(flags) {}
+        Registration(Symbol name, Flags<Options> flags = {})
+            : name(name), flags(flags) {}
 
         Rc<Registration> self() const {
             return _self
@@ -146,9 +147,6 @@ export struct Property : Meta::NoCopy {
         }
 
         virtual ~Registration() = default;
-
-        /// Returns the canonical CSS identifier for this property (e.g., `color`, `margin-top`).
-        virtual Symbol name() const = 0;
 
         /// The pass in which the property belongs, non-trivial
         /// overrides of this method should be justified with a comment.
@@ -171,7 +169,7 @@ export struct Property : Meta::NoCopy {
             //       commonly inherited. Any property marked with the INHERITED
             //       flag should override this method with a faster implementation.
             if (flags.has(INHERITED))
-                logFatal("property {:#} marked as INHERITED is using the slow fallback path. override inherit()!", name());
+                logFatal("property {:#} marked as INHERITED is using the slow fallback path. override inherit()!", name);
 
             // NOTE: Since we are copying computed values, we don't expect much new computation to happen
             ComputationContext dummy{};
@@ -200,17 +198,17 @@ export struct Property : Meta::NoCopy {
 
     virtual Vec<Rc<Property>> expandShorthand(RegisteredPropertySet&, [[maybe_unused]] ComputedValues const& parent, [[maybe_unused]] ComputedValues& child) const {
         if (isBogusProperty())
-            logFatal("trying to expand {:#} which is a bogus property", registration->name());
+            logFatal("trying to expand {:#} which is a bogus property", registration->name);
 
         if (isShorthandProperty())
-            logFatal("shorthand property {:#} is missing expandShorthand() implementation", registration->name());
+            logFatal("shorthand property {:#} is missing expandShorthand() implementation", registration->name);
 
-        logFatal("expandShorthand() called on non shorthand property {:#}", registration->name());
+        logFatal("expandShorthand() called on non shorthand property {:#}", registration->name);
         return {};
     }
 
     virtual void apply([[maybe_unused]] ComputedValues const& parent, [[maybe_unused]] ComputedValues& child, [[maybe_unused]] ComputationContext const& cx) const {
-        logFatal("longhand property {:#} is missing apply() implementation", registration->name());
+        logFatal("longhand property {:#} is missing apply() implementation", registration->name);
     }
 
     virtual void repr(Io::Emit& e) const = 0;
@@ -257,15 +255,8 @@ export struct Property : Meta::NoCopy {
 // this symbolizes a custom property, it starts with `--` and can be used to store a value that can be reused in the stylesheet
 struct CustomProperty : Property {
     struct Registration : Property::Registration {
-        Symbol _name;
-
         Registration(Symbol name)
-            : Property::Registration({INHERITED, CUSTOM_PROPERTY, ALL_EXCLUDED, BULK_INHERITED}),
-              _name(name) {}
-
-        Symbol name() const override {
-            return _name;
-        }
+            : Property::Registration(name, {INHERITED, CUSTOM_PROPERTY, ALL_EXCLUDED, BULK_INHERITED}) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::CUSTOM_PROPERTY;
@@ -278,12 +269,12 @@ struct CustomProperty : Property {
         }
 
         void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            if (auto maybeProp = parent.getCustomProp(_name))
-                child.setCustomProp(_name, maybeProp.unwrap());
+            if (auto maybeProp = parent.getCustomProp(name))
+                child.setCustomProp(name, maybeProp.unwrap());
         }
 
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<CustomProperty>(self(), c.getCustomProp(_name).unwrapOr({}));
+            return makeRc<CustomProperty>(self(), c.getCustomProp(name).unwrapOr({}));
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -299,7 +290,7 @@ struct CustomProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.setCustomProp(registration->name(), _value);
+        c.setCustomProp(registration->name, _value);
     }
 
     void repr(Io::Emit& e) const override {
@@ -325,7 +316,7 @@ struct ToggleProperty : Property {
         Map<Symbol, Vec<Rc<Property>>> props;
         for (auto& shorthand : _value)
             for (auto& longhand : shorthand->expandShorthand(registry, parent, child))
-                props.lookupOrPutDefault(longhand->registration->name()).pushBack(longhand);
+                props.lookupOrPutDefault(longhand->registration->name).pushBack(longhand);
 
         return props.mutIterValue() |
                Select([](Vec<Rc<Property>>& v) {
@@ -444,14 +435,14 @@ struct DeferredProperty : Property {
 
         auto prop = registration->parse(cursor);
         if (not prop and debugProperties)
-            logWarn("failed to parse declaration: {}: {}: {}", registration->name(), prop, out);
+            logWarn("failed to parse declaration: {}: {}: {}", registration->name, prop, out);
 
         return prop;
     }
 
     Vec<Rc<Property>> expandShorthand(RegisteredPropertySet& registry, ComputedValues const& parent, ComputedValues& child) const override {
         if (not isShorthandProperty())
-            logFatal("expandShorthand called on non shorthand property {:#}", registration->name());
+            logFatal("expandShorthand called on non shorthand property {:#}", registration->name);
 
         auto prop = _expandProperty(child);
         if (not prop)
@@ -556,15 +547,8 @@ struct DefaultedProperty : Property {
 // Represent a property that could not be parsed
 struct BogusProperty : Property {
     struct Registration : Property::Registration {
-        Symbol _name;
-
         Registration(Symbol const name)
-            : Property::Registration(BOGUS_REGISTRATION),
-              _name(name) {}
-
-        Symbol name() const override {
-            return _name;
-        }
+            : Property::Registration(name, BOGUS_REGISTRATION) {}
 
         Rc<Property> initial() const override {
             unreachable();
@@ -634,7 +618,7 @@ export struct RegisteredPropertySet {
             _presentationAttributes.put(propertyName, registration);
 
         for (auto legacyAlias : registration->legacyAlias())
-            _legacyAlias.put(legacyAlias, registration->name());
+            _legacyAlias.put(legacyAlias, registration->name);
 
         if (registrationFlags.has(Property::INHERITED) and
             not registrationFlags.has(Property::BULK_INHERITED))
@@ -647,7 +631,7 @@ export struct RegisteredPropertySet {
     void registerProperty() {
         auto registration = makeRc<typename Property::Registration>();
         registration->_self = Some(registration);
-        registerProperty(registration->name(), registration);
+        registerProperty(registration->name, registration);
     }
 
     Rc<Property::Registration> registerCustomProperty(Symbol const& propertyName) {

--- a/src/vaev-engine/props/baseline.cpp
+++ b/src/vaev-engine/props/baseline.cpp
@@ -17,11 +17,7 @@ namespace Vaev::Style {
 export struct LineHeightProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::LINE_HEIGHT;
-        }
+            : Property::Registration(Properties::LINE_HEIGHT, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<LineHeightProperty>(self(), Keywords::NORMAL);
@@ -57,9 +53,7 @@ export struct LineHeightProperty : Property {
 // https://www.w3.org/TR/css-inline-3/#dominant-baseline-property
 export struct DominantBaselineProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::DOMINANT_BASELINE;
-        }
+        Registration() : Property::Registration(Properties::DOMINANT_BASELINE) {}
 
         Rc<Property> initial() const override {
             return makeRc<DominantBaselineProperty>(self(), Keywords::AUTO);
@@ -91,9 +85,7 @@ export struct DominantBaselineProperty : Property {
 // https://www.w3.org/TR/css-inline-3/#baseline-source
 export struct BaselineSourceProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BASELINE_SOURCE;
-        }
+        Registration() : Property::Registration(Properties::BASELINE_SOURCE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BaselineSourceProperty>(self(), Keywords::AUTO);
@@ -125,9 +117,7 @@ export struct BaselineSourceProperty : Property {
 // https://www.w3.org/TR/css-inline-3/#alignment-baseline-property
 export struct AlignmentBaselineProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::ALIGNMENT_BASELINE;
-        }
+        Registration() : Property::Registration(Properties::ALIGNMENT_BASELINE) {}
 
         Rc<Property> initial() const override {
             return makeRc<AlignmentBaselineProperty>(self(), Keywords::BASELINE);
@@ -159,9 +149,7 @@ export struct AlignmentBaselineProperty : Property {
 // https://drafts.csswg.org/css-inline/#propdef-baseline-shift
 export struct BaselineShiftProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BASELINE_SHIFT;
-        }
+        Registration() : Property::Registration(Properties::BASELINE_SHIFT) {}
 
         Rc<Property> initial() const override {
             return makeRc<BaselineShiftProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -200,11 +188,7 @@ export struct VerticalAlignProperty : Property {
 
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::VERTICAL_ALIGN;
-        }
+            : Property::Registration(Properties::VERTICAL_ALIGN, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<VerticalAlignProperty>(self(), Value{.alignmentBaseline = Some(Keywords::BASELINE)});

--- a/src/vaev-engine/props/border.cpp
+++ b/src/vaev-engine/props/border.cpp
@@ -18,9 +18,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/CSS22/box.html#propdef-border-color
 export struct BorderTopColorProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_TOP_COLOR;
-        }
+        Registration() : Property::Registration(Properties::BORDER_TOP_COLOR) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderTopColorProperty>(self(), BLACK);
@@ -52,9 +50,7 @@ export struct BorderTopColorProperty : Property {
 // https://www.w3.org/TR/CSS22/box.html#propdef-border-color
 export struct BorderRightColorProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_RIGHT_COLOR;
-        }
+        Registration() : Property::Registration(Properties::BORDER_RIGHT_COLOR) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRightColorProperty>(self(), BLACK);
@@ -86,9 +82,7 @@ export struct BorderRightColorProperty : Property {
 // https://www.w3.org/TR/CSS22/box.html#propdef-border-color
 export struct BorderBottomColorProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_BOTTOM_COLOR;
-        }
+        Registration() : Property::Registration(Properties::BORDER_BOTTOM_COLOR) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderBottomColorProperty>(self(), BLACK);
@@ -120,9 +114,7 @@ export struct BorderBottomColorProperty : Property {
 // https://www.w3.org/TR/CSS22/box.html#propdef-border-color
 export struct BorderLeftColorProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_LEFT_COLOR;
-        }
+        Registration() : Property::Registration(Properties::BORDER_LEFT_COLOR) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderLeftColorProperty>(self(), BLACK);
@@ -154,11 +146,7 @@ export struct BorderLeftColorProperty : Property {
 export struct BorderColorProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_COLOR;
-        }
+            : Property::Registration(Properties::BORDER_COLOR, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderColorProperty>(self(), Math::Insets<Color>{BLACK});
@@ -204,9 +192,7 @@ export struct BorderColorProperty : Property {
 // https://www.w3.org/TR/CSS22/box.html#border-style-properties
 export struct BorderLeftStyleProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_LEFT_STYLE;
-        }
+        Registration() : Property::Registration(Properties::BORDER_LEFT_STYLE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderLeftStyleProperty>(self(), Gfx::BorderStyle::NONE);
@@ -238,9 +224,7 @@ export struct BorderLeftStyleProperty : Property {
 // https://www.w3.org/TR/CSS22/box.html#border-style-properties
 export struct BorderTopStyleProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_TOP_STYLE;
-        }
+        Registration() : Property::Registration(Properties::BORDER_TOP_STYLE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderTopStyleProperty>(self(), Gfx::BorderStyle::NONE);
@@ -272,9 +256,7 @@ export struct BorderTopStyleProperty : Property {
 // https://www.w3.org/TR/CSS22/box.html#border-style-properties
 export struct BorderRightStyleProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_RIGHT_STYLE;
-        }
+        Registration() : Property::Registration(Properties::BORDER_RIGHT_STYLE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRightStyleProperty>(self(), Gfx::BorderStyle::NONE);
@@ -306,9 +288,7 @@ export struct BorderRightStyleProperty : Property {
 // https://www.w3.org/TR/CSS22/box.html#border-style-properties
 export struct BorderBottomStyleProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_BOTTOM_STYLE;
-        }
+        Registration() : Property::Registration(Properties::BORDER_BOTTOM_STYLE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderBottomStyleProperty>(self(), Gfx::BorderStyle::NONE);
@@ -342,11 +322,7 @@ export struct BorderBottomStyleProperty : Property {
 export struct BorderStyleProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_STYLE;
-        }
+            : Property::Registration(Properties::BORDER_STYLE, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderStyleProperty>(self(), Math::Insets{Gfx::BorderStyle::NONE});
@@ -391,9 +367,7 @@ export struct BorderStyleProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-width
 export struct BorderTopWidthProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_TOP_WIDTH;
-        }
+        Registration() : Property::Registration(Properties::BORDER_TOP_WIDTH) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderTopWidthProperty>(self(), Keywords::MEDIUM);
@@ -425,9 +399,7 @@ export struct BorderTopWidthProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-width
 export struct BorderRightWidthProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_RIGHT_WIDTH;
-        }
+        Registration() : Property::Registration(Properties::BORDER_RIGHT_WIDTH) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRightWidthProperty>(self(), Keywords::MEDIUM);
@@ -459,9 +431,7 @@ export struct BorderRightWidthProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-width
 export struct BorderBottomWidthProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_BOTTOM_WIDTH;
-        }
+        Registration() : Property::Registration(Properties::BORDER_BOTTOM_WIDTH) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderBottomWidthProperty>(self(), Keywords::MEDIUM);
@@ -493,9 +463,7 @@ export struct BorderBottomWidthProperty : Property {
 // https://www.w3.org/TR/css-backgrounds-3/#border-width
 export struct BorderLeftWidthProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_LEFT_WIDTH;
-        }
+        Registration() : Property::Registration(Properties::BORDER_LEFT_WIDTH) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderLeftWidthProperty>(self(), Keywords::MEDIUM);
@@ -527,9 +495,7 @@ export struct BorderLeftWidthProperty : Property {
 // https://drafts.csswg.org/css-backgrounds/#the-border-radius
 export struct BorderRadiusTopRightProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_TOP_RIGHT_RADIUS;
-        }
+        Registration() : Property::Registration(Properties::BORDER_TOP_RIGHT_RADIUS) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRadiusTopRightProperty>(self(), makeArray<Calc<PercentOr<Length>>, 2>(Length{}));
@@ -569,9 +535,7 @@ export struct BorderRadiusTopRightProperty : Property {
 // https://drafts.csswg.org/css-backgrounds/#the-border-radius
 export struct BorderRadiusTopLeftProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_TOP_LEFT_RADIUS;
-        }
+        Registration() : Property::Registration(Properties::BORDER_TOP_LEFT_RADIUS) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRadiusTopLeftProperty>(self(), makeArray<Calc<PercentOr<Length>>, 2>(Length{}));
@@ -614,9 +578,7 @@ export struct BorderRadiusTopLeftProperty : Property {
 // https://drafts.csswg.org/css-backgrounds/#the-border-radius
 export struct BorderRadiusBottomRightProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_BOTTOM_RIGHT_RADIUS;
-        }
+        Registration() : Property::Registration(Properties::BORDER_BOTTOM_RIGHT_RADIUS) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRadiusBottomRightProperty>(self(), makeArray<Calc<PercentOr<Length>>, 2>(Length{}));
@@ -656,9 +618,7 @@ export struct BorderRadiusBottomRightProperty : Property {
 // https://drafts.csswg.org/css-backgrounds/#the-border-radius
 export struct BorderRadiusBottomLeftProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_BOTTOM_LEFT_RADIUS;
-        }
+        Registration() : Property::Registration(Properties::BORDER_BOTTOM_LEFT_RADIUS) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRadiusBottomLeftProperty>(self(), makeArray<Calc<PercentOr<Length>>, 2>(Length{}));
@@ -701,9 +661,7 @@ export struct BorderRadiusBottomLeftProperty : Property {
 // https://drafts.csswg.org/css-backgrounds/#the-border-radius
 export struct BorderRadiusProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BORDER_RADIUS;
-        }
+        Registration() : Property::Registration(Properties::BORDER_RADIUS) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRadiusProperty>(self(), Math::Radii{Calc<PercentOr<Length>>(Length{})});
@@ -737,11 +695,7 @@ export struct BorderRadiusProperty : Property {
 export struct BorderTopProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_TOP;
-        }
+            : Property::Registration(Properties::BORDER_TOP, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderTopProperty>(self(), SpecifiedBorder{});
@@ -800,11 +754,7 @@ export struct BorderTopProperty : Property {
 export struct BorderRightProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_RIGHT;
-        }
+            : Property::Registration(Properties::BORDER_RIGHT, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderRightProperty>(self(), SpecifiedBorder{});
@@ -841,11 +791,7 @@ export struct BorderRightProperty : Property {
 export struct BorderBottomProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_BOTTOM;
-        }
+            : Property::Registration(Properties::BORDER_BOTTOM, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderBottomProperty>(self(), SpecifiedBorder{});
@@ -882,11 +828,7 @@ export struct BorderBottomProperty : Property {
 export struct BorderLeftProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_LEFT;
-        }
+            : Property::Registration(Properties::BORDER_LEFT, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderLeftProperty>(self(), SpecifiedBorder{});
@@ -923,11 +865,7 @@ export struct BorderLeftProperty : Property {
 export struct BorderProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER;
-        }
+            : Property::Registration(Properties::BORDER, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderProperty>(self(), SpecifiedBorder{});
@@ -976,11 +914,7 @@ export struct BorderProperty : Property {
 export struct BorderWidthProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_WIDTH;
-        }
+            : Property::Registration(Properties::BORDER_WIDTH, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderWidthProperty>(self(), Math::Insets{LineWidth{Keywords::MEDIUM}});
@@ -1028,11 +962,7 @@ export struct BorderWidthProperty : Property {
 export struct BorderCollapseProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_COLLAPSE;
-        }
+            : Property::Registration(Properties::BORDER_COLLAPSE, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderCollapseProperty>(self(), BorderCollapse::SEPARATE);
@@ -1069,11 +999,7 @@ export struct BorderCollapseProperty : Property {
 export struct BorderSpacingProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::BORDER_SPACING;
-        }
+            : Property::Registration(Properties::BORDER_SPACING, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderSpacingProperty>(self(), BorderSpacing{0_au, 0_au});

--- a/src/vaev-engine/props/breaks.cpp
+++ b/src/vaev-engine/props/breaks.cpp
@@ -18,9 +18,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/css-break-3/#propdef-break-after
 export struct BreakAfterProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BREAK_AFTER;
-        }
+        Registration() : Property::Registration(Properties::BREAK_AFTER) {}
 
         Rc<Property> initial() const override {
             return makeRc<BreakAfterProperty>(self(), BreakBetween::AUTO);
@@ -52,9 +50,7 @@ export struct BreakAfterProperty : Property {
 // https://www.w3.org/TR/css-break-3/#propdef-break-before
 export struct BreakBeforeProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BREAK_BEFORE;
-        }
+        Registration() : Property::Registration(Properties::BREAK_BEFORE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BreakBeforeProperty>(self(), BreakBetween::AUTO);
@@ -86,9 +82,7 @@ export struct BreakBeforeProperty : Property {
 // https://www.w3.org/TR/css-break-3/#break-within
 export struct BreakInsideProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BREAK_INSIDE;
-        }
+        Registration() : Property::Registration(Properties::BREAK_INSIDE) {}
 
         Rc<Property> initial() const override {
             return makeRc<BreakInsideProperty>(self(), BreakInside::AUTO);

--- a/src/vaev-engine/props/counter.cpp
+++ b/src/vaev-engine/props/counter.cpp
@@ -14,9 +14,7 @@ namespace Vaev::Style {
 // https://drafts.csswg.org/css-lists/#counter-reset
 export struct CounterResetProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::COUNTER_RESET;
-        }
+        Registration() : Property::Registration(Properties::COUNTER_RESET) {}
 
         Rc<Property> initial() const override {
             return makeRc<CounterResetProperty>(self(), Vec<CounterProps::Reset>{});
@@ -51,9 +49,7 @@ export struct CounterResetProperty : Property {
 // https://drafts.csswg.org/css-lists/#propdef-counter-increment
 export struct CounterIncrementProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::COUNTER_INCREMENT;
-        }
+        Registration() : Property::Registration(Properties::COUNTER_INCREMENT) {}
 
         Rc<Property> initial() const override {
             return makeRc<CounterIncrementProperty>(self(), Vec<CounterProps::Increment>{});
@@ -88,9 +84,7 @@ export struct CounterIncrementProperty : Property {
 // https://drafts.csswg.org/css-lists/#propdef-counter-set
 export struct CounterSetProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::COUNTER_SET;
-        }
+        Registration() : Property::Registration(Properties::COUNTER_SET) {}
 
         Rc<Property> initial() const override {
             return makeRc<CounterSetProperty>(self(), Vec<CounterProps::Set>{});

--- a/src/vaev-engine/props/display.cpp
+++ b/src/vaev-engine/props/display.cpp
@@ -16,9 +16,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/CSS22/visuren.html#propdef-display
 export struct DisplayProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::DISPLAY;
-        }
+        Registration() : Property::Registration(Properties::DISPLAY) {}
 
         Rc<Property> initial() const override {
             return makeRc<DisplayProperty>(self(), Display{Display::FLOW, Display::INLINE});
@@ -51,9 +49,7 @@ export struct DisplayProperty : Property {
 // https://drafts.csswg.org/css-content/#content-property
 export struct ContentProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::CONTENT;
-        }
+        Registration() : Property::Registration(Properties::CONTENT) {}
 
         Rc<Property> initial() const override {
             return makeRc<ContentProperty>(self(), Keywords::NORMAL);
@@ -85,9 +81,7 @@ export struct ContentProperty : Property {
 // https://www.w3.org/TR/css-display-3/#order-property
 export struct OrderProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::ORDER;
-        }
+        Registration() : Property::Registration(Properties::ORDER) {}
 
         Rc<Property> initial() const override {
             return makeRc<OrderProperty>(self(), Integer{0});

--- a/src/vaev-engine/props/flex.cpp
+++ b/src/vaev-engine/props/flex.cpp
@@ -18,9 +18,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/css-flexbox-1/#flex-basis-property
 export struct FlexBasisProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::FLEX_BASIS;
-        }
+        Registration() : Property::Registration(Properties::FLEX_BASIS) {}
 
         Rc<Property> initial() const override {
             return makeRc<FlexBasisProperty>(self(), Keywords::AUTO);
@@ -52,9 +50,7 @@ export struct FlexBasisProperty : Property {
 // https://www.w3.org/TR/css-flexbox-1/#propdef-flex-direction
 export struct FlexDirectionProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::FLEX_DIRECTION;
-        }
+        Registration() : Property::Registration(Properties::FLEX_DIRECTION) {}
 
         Rc<Property> initial() const override {
             return makeRc<FlexDirectionProperty>(self(), FlexDirection::ROW);
@@ -86,9 +82,7 @@ export struct FlexDirectionProperty : Property {
 // https://www.w3.org/TR/css-flexbox-1/#flex-grow-property
 export struct FlexGrowProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::FLEX_GROW;
-        }
+        Registration() : Property::Registration(Properties::FLEX_GROW) {}
 
         Rc<Property> initial() const override {
             return makeRc<FlexGrowProperty>(self(), Number{0});
@@ -120,9 +114,7 @@ export struct FlexGrowProperty : Property {
 // https://www.w3.org/TR/css-flexbox-1/#propdef-flex-shrink
 export struct FlexShrinkProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::FLEX_SHRINK;
-        }
+        Registration() : Property::Registration(Properties::FLEX_SHRINK) {}
 
         Rc<Property> initial() const override {
             return makeRc<FlexShrinkProperty>(self(), Number{1});
@@ -154,9 +146,7 @@ export struct FlexShrinkProperty : Property {
 // https://www.w3.org/TR/css-flexbox-1/#propdef-flex-wrap
 export struct FlexWrapProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::FLEX_WRAP;
-        }
+        Registration() : Property::Registration(Properties::FLEX_WRAP) {}
 
         Rc<Property> initial() const override {
             return makeRc<FlexWrapProperty>(self(), FlexWrap::NOWRAP);
@@ -189,11 +179,7 @@ export struct FlexWrapProperty : Property {
 export struct FlexFlowProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::FLEX_FLOW;
-        }
+            : Property::Registration(Properties::FLEX_FLOW, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<FlexFlowProperty>(self(), Tuple{FlexDirection::ROW, FlexWrap::NOWRAP});
@@ -252,11 +238,7 @@ export struct FlexFlowProperty : Property {
 export struct FlexProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::FLEX;
-        }
+            : Property::Registration(Properties::FLEX, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<FlexProperty>(self(), FlexItemProps{Keywords::AUTO, 0, 1});

--- a/src/vaev-engine/props/floats.cpp
+++ b/src/vaev-engine/props/floats.cpp
@@ -17,9 +17,7 @@ namespace Vaev::Style {
 
 export struct FloatProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::FLOAT;
-        }
+        Registration() : Property::Registration(Properties::FLOAT) {}
 
         Rc<Property> initial() const override {
             return makeRc<FloatProperty>(self(), Float::NONE);
@@ -50,9 +48,7 @@ export struct FloatProperty : Property {
 
 export struct ClearProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::CLEAR;
-        }
+        Registration() : Property::Registration(Properties::CLEAR) {}
 
         Rc<Property> initial() const override {
             return makeRc<ClearProperty>(self(), Clear::NONE);

--- a/src/vaev-engine/props/fonts.cpp
+++ b/src/vaev-engine/props/fonts.cpp
@@ -19,11 +19,7 @@ namespace Vaev::Style {
 export struct FontFamilyProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::FONT_FAMILY;
-        }
+            : Property::Registration(Properties::FONT_FAMILY, INHERITED) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;
@@ -73,11 +69,7 @@ export struct FontFamilyProperty : Property {
 export struct FontWeightProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::FONT_WEIGHT;
-        }
+            : Property::Registration(Properties::FONT_WEIGHT, INHERITED) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;
@@ -118,11 +110,7 @@ export struct FontWeightProperty : Property {
 export struct FontWidthProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::FONT_WIDTH;
-        }
+            : Property::Registration(Properties::FONT_WIDTH, INHERITED) {}
 
         // https://drafts.csswg.org/css-fonts/#font-stretch-prop
         Vec<Symbol> legacyAlias() const override {
@@ -168,11 +156,7 @@ export struct FontWidthProperty : Property {
 export struct FontStyleProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::FONT_STYLE;
-        }
+            : Property::Registration(Properties::FONT_STYLE, INHERITED) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;
@@ -213,11 +197,7 @@ export struct FontStyleProperty : Property {
 export struct FontSizeProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::FONT_SIZE;
-        }
+            : Property::Registration(Properties::FONT_SIZE, INHERITED) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;
@@ -276,11 +256,7 @@ export struct FontProperty : Property {
 
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::FONT;
-        }
+            : Property::Registration(Properties::FONT, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<FontProperty>(self(), Value{});

--- a/src/vaev-engine/props/list.cpp
+++ b/src/vaev-engine/props/list.cpp
@@ -12,11 +12,7 @@ namespace Vaev::Style {
 struct ListStyleImageProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::LIST_STYLE_IMAGE;
-        }
+            : Property::Registration(Properties::LIST_STYLE_IMAGE, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<ListStyleImageProperty>(self(), Keywords::NONE);
@@ -54,11 +50,7 @@ struct ListStyleImageProperty : Property {
 struct ListStyleTypeProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::LIST_STYLE_TYPE;
-        }
+            : Property::Registration(Properties::LIST_STYLE_TYPE, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<ListStyleTypeProperty>(self(), CustomIdent{"disc"_sym});
@@ -96,11 +88,7 @@ struct ListStyleTypeProperty : Property {
 struct ListStylePositionProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::LIST_STYLE_POSITION;
-        }
+            : Property::Registration(Properties::LIST_STYLE_POSITION, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<ListStylePositionProperty>(self(), Keywords::OUTSIDE);
@@ -148,11 +136,7 @@ struct ListStyleProperty : Property {
 
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::LIST_STYLE;
-        }
+            : Property::Registration(Properties::LIST_STYLE, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<ListStyleProperty>(self(), Value{});
@@ -224,11 +208,7 @@ struct ListStyleProperty : Property {
 struct MarkerSideProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::MARKER_SIDE;
-        }
+            : Property::Registration(Properties::MARKER_SIDE, INHERITED) {}
 
         void inherit(ComputedValues const& parent, ComputedValues& child) const override {
             child.list.cow().markerSide = parent.list->markerSide;

--- a/src/vaev-engine/props/margin.cpp
+++ b/src/vaev-engine/props/margin.cpp
@@ -18,9 +18,7 @@ export struct MarginTopProperty : Property {
     using Value = Union<Keywords::Auto, Calc<PercentOr<Length>>>;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_TOP;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_TOP) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginTopProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -54,9 +52,7 @@ export struct MarginRightProperty : Property {
     using Value = MarginTopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_RIGHT;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_RIGHT) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginRightProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -90,9 +86,7 @@ export struct MarginBottomProperty : Property {
     using Value = MarginTopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_BOTTOM;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_BOTTOM) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginBottomProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -126,9 +120,7 @@ export struct MarginLeftProperty : Property {
     using Value = MarginTopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_LEFT;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_LEFT) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginLeftProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -163,11 +155,7 @@ export struct MarginProperty : Property {
 
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::MARGIN;
-        }
+            : Property::Registration(Properties::MARGIN, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginProperty>(self(), Value{Calc<PercentOr<Length>>(Length{})});
@@ -206,9 +194,7 @@ export struct MarginInlineStartProperty : Property {
     using Value = MarginTopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_INLINE_START;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_INLINE_START) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginInlineStartProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -243,9 +229,7 @@ export struct MarginInlineEndProperty : Property {
     using Value = MarginTopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_INLINE_END;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_INLINE_END) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginInlineEndProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -280,9 +264,7 @@ export struct MarginInlineProperty : Property {
     using Value = Math::Insets<MarginTopProperty::Value>;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_INLINE;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_INLINE) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginInlineProperty>(self(), Value{Calc<PercentOr<Length>>(Length{})});
@@ -318,9 +300,7 @@ export struct MarginBlockStartProperty : Property {
     using Value = MarginTopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_BLOCK_START;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_BLOCK_START) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginBlockStartProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -355,9 +335,7 @@ export struct MarginBlockEndProperty : Property {
     using Value = MarginTopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_BLOCK_END;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_BLOCK_END) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginBlockEndProperty>(self(), Calc<PercentOr<Length>>(Length{}));
@@ -392,9 +370,7 @@ export struct MarginBlockProperty : Property {
     using Value = Math::Insets<MarginTopProperty::Value>;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MARGIN_BLOCK;
-        }
+        Registration() : Property::Registration(Properties::MARGIN_BLOCK) {}
 
         Rc<Property> initial() const override {
             return makeRc<MarginBlockProperty>(self(), Value{Calc<PercentOr<Length>>(Length{})});

--- a/src/vaev-engine/props/outline.cpp
+++ b/src/vaev-engine/props/outline.cpp
@@ -18,9 +18,7 @@ namespace Vaev::Style {
 // https://drafts.csswg.org/css-ui/#outline-width
 export struct OutlineWidthProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OUTLINE_WIDTH;
-        }
+        Registration() : Property::Registration(Properties::OUTLINE_WIDTH) {}
 
         Rc<Property> initial() const override {
             return makeRc<OutlineWidthProperty>(self(), LineWidth{Keywords::MEDIUM});
@@ -54,9 +52,7 @@ export struct OutlineStyleProperty : Property {
     using Value = Union<Keywords::Auto, Gfx::BorderStyle>;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OUTLINE_STYLE;
-        }
+        Registration() : Property::Registration(Properties::OUTLINE_STYLE) {}
 
         Rc<Property> initial() const override {
             return makeRc<OutlineStyleProperty>(self(), Value{Gfx::BorderStyle::NONE});
@@ -90,9 +86,7 @@ export struct OutlineColorProperty : Property {
     using Value = Union<Keywords::Auto, Color>;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OUTLINE_COLOR;
-        }
+        Registration() : Property::Registration(Properties::OUTLINE_COLOR) {}
 
         ComputationPhase computationPhase() const override {
             // Must be applied after 'outline-style'.
@@ -141,9 +135,7 @@ export struct OutlineColorProperty : Property {
 // https://drafts.csswg.org/css-ui/#outline-offset
 export struct OutlineOffsetProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OUTLINE_OFFSET;
-        }
+        Registration() : Property::Registration(Properties::OUTLINE_OFFSET) {}
 
         Rc<Property> initial() const override {
             return makeRc<OutlineOffsetProperty>(self(), Calc<Length>{0_au});
@@ -176,11 +168,7 @@ export struct OutlineOffsetProperty : Property {
 export struct OutlineProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::OUTLINE;
-        }
+            : Property::Registration(Properties::OUTLINE, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<OutlineProperty>(self(), SpecifiedOutline{});

--- a/src/vaev-engine/props/overflow.cpp
+++ b/src/vaev-engine/props/overflow.cpp
@@ -18,9 +18,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/css-overflow/#overflow-control
 export struct OverflowXProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OVERFLOW_X;
-        }
+        Registration() : Property::Registration(Properties::OVERFLOW_X) {}
 
         Rc<Property> initial() const override {
             return makeRc<OverflowXProperty>(self(), Overflow::VISIBLE);
@@ -52,9 +50,7 @@ export struct OverflowXProperty : Property {
 // https://www.w3.org/TR/css-overflow/#overflow-control
 export struct OverflowYProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OVERFLOW_Y;
-        }
+        Registration() : Property::Registration(Properties::OVERFLOW_Y) {}
 
         Rc<Property> initial() const override {
             return makeRc<OverflowYProperty>(self(), Overflow::VISIBLE);
@@ -86,9 +82,7 @@ export struct OverflowYProperty : Property {
 // https://www.w3.org/TR/css-overflow/#overflow-block
 export struct OverflowBlockProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OVERFLOW_BLOCK;
-        }
+        Registration() : Property::Registration(Properties::OVERFLOW_BLOCK) {}
 
         Rc<Property> initial() const override {
             return makeRc<OverflowBlockProperty>(self(), Overflow::VISIBLE);
@@ -120,9 +114,7 @@ export struct OverflowBlockProperty : Property {
 // https://www.w3.org/TR/css-overflow/#overflow-inline
 export struct OverflowInlineProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OVERFLOW_INLINE;
-        }
+        Registration() : Property::Registration(Properties::OVERFLOW_INLINE) {}
 
         Rc<Property> initial() const override {
             return makeRc<OverflowInlineProperty>(self(), Overflow::VISIBLE);
@@ -155,11 +147,7 @@ export struct OverflowInlineProperty : Property {
 export struct OverflowProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::OVERFLOW;
-        }
+            : Property::Registration(Properties::OVERFLOW, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<OverflowProperty>(self(), Pair{Overflow::VISIBLE, Overflow::VISIBLE});

--- a/src/vaev-engine/props/padding.cpp
+++ b/src/vaev-engine/props/padding.cpp
@@ -19,9 +19,7 @@ namespace Vaev::Style {
 
 export struct PaddingTopProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::PADDING_TOP;
-        }
+        Registration() : Property::Registration(Properties::PADDING_TOP) {}
 
         Rc<Property> initial() const override {
             return makeRc<PaddingTopProperty>(self(), Calc<PercentOr<Length>>{Length{}});
@@ -52,9 +50,7 @@ export struct PaddingTopProperty : Property {
 
 export struct PaddingRightProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::PADDING_RIGHT;
-        }
+        Registration() : Property::Registration(Properties::PADDING_RIGHT) {}
 
         Rc<Property> initial() const override {
             return makeRc<PaddingRightProperty>(self(), Calc<PercentOr<Length>>{Length{}});
@@ -85,9 +81,7 @@ export struct PaddingRightProperty : Property {
 
 export struct PaddingBottomProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::PADDING_BOTTOM;
-        }
+        Registration() : Property::Registration(Properties::PADDING_BOTTOM) {}
 
         Rc<Property> initial() const override {
             return makeRc<PaddingBottomProperty>(self(), Calc<PercentOr<Length>>{Length{}});
@@ -118,9 +112,7 @@ export struct PaddingBottomProperty : Property {
 
 export struct PaddingLeftProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::PADDING_LEFT;
-        }
+        Registration() : Property::Registration(Properties::PADDING_LEFT) {}
 
         Rc<Property> initial() const override {
             return makeRc<PaddingLeftProperty>(self(), Calc<PercentOr<Length>>{Length{}});
@@ -151,9 +143,7 @@ export struct PaddingLeftProperty : Property {
 
 export struct PaddingInlineStartProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::PADDING_INLINE_START;
-        }
+        Registration() : Property::Registration(Properties::PADDING_INLINE_START) {}
 
         Rc<Property> initial() const override {
             return makeRc<PaddingInlineStartProperty>(self(), Calc<PercentOr<Length>>{Length{}});
@@ -184,9 +174,7 @@ export struct PaddingInlineStartProperty : Property {
 
 export struct PaddingInlineEndProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::PADDING_INLINE_END;
-        }
+        Registration() : Property::Registration(Properties::PADDING_INLINE_END) {}
 
         Rc<Property> initial() const override {
             return makeRc<PaddingInlineEndProperty>(self(), Calc<PercentOr<Length>>{Length{}});
@@ -218,11 +206,7 @@ export struct PaddingInlineEndProperty : Property {
 export struct PaddingProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(SHORTHAND_PROPERTY) {}
-
-        Symbol name() const override {
-            return Properties::PADDING;
-        }
+            : Property::Registration(Properties::PADDING, SHORTHAND_PROPERTY) {}
 
         Rc<Property> initial() const override {
             return makeRc<PaddingProperty>(self(), Math::Insets<Calc<PercentOr<Length>>>{Length{}});

--- a/src/vaev-engine/props/positioned.cpp
+++ b/src/vaev-engine/props/positioned.cpp
@@ -18,9 +18,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/CSS22/visuren.html#positioning-scheme
 export struct PositionProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::POSITION;
-        }
+        Registration() : Property::Registration(Properties::POSITION) {}
 
         Rc<Property> initial() const override {
             return makeRc<PositionProperty>(self(), Position{Keywords::STATIC});
@@ -54,9 +52,7 @@ export struct TopProperty : Property {
     using Value = Union<Keywords::Auto, Calc<PercentOr<Length>>>;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::TOP;
-        }
+        Registration() : Property::Registration(Properties::TOP) {}
 
         Rc<Property> initial() const override {
             return makeRc<TopProperty>(self(), Value{Keywords::AUTO});
@@ -90,9 +86,7 @@ export struct RightProperty : Property {
     using Value = TopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::RIGHT;
-        }
+        Registration() : Property::Registration(Properties::RIGHT) {}
 
         Rc<Property> initial() const override {
             return makeRc<RightProperty>(self(), Value{Keywords::AUTO});
@@ -126,9 +120,7 @@ export struct BottomProperty : Property {
     using Value = TopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BOTTOM;
-        }
+        Registration() : Property::Registration(Properties::BOTTOM) {}
 
         Rc<Property> initial() const override {
             return makeRc<BottomProperty>(self(), Value{Keywords::AUTO});
@@ -162,9 +154,7 @@ export struct LeftProperty : Property {
     using Value = TopProperty::Value;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::LEFT;
-        }
+        Registration() : Property::Registration(Properties::LEFT) {}
 
         Rc<Property> initial() const override {
             return makeRc<LeftProperty>(self(), Value{Keywords::AUTO});
@@ -196,9 +186,7 @@ export struct LeftProperty : Property {
 // https://drafts.csswg.org/css2/#z-index
 export struct ZIndexProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::Z_INDEX;
-        }
+        Registration() : Property::Registration(Properties::Z_INDEX) {}
 
         Rc<Property> initial() const override {
             return makeRc<ZIndexProperty>(self(), ZIndex{Keywords::AUTO});

--- a/src/vaev-engine/props/sizing.cpp
+++ b/src/vaev-engine/props/sizing.cpp
@@ -19,9 +19,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/css-sizing-3/#box-sizing
 export struct BoxSizingProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::BOX_SIZING;
-        }
+        Registration() : Property::Registration(Properties::BOX_SIZING) {}
 
         Rc<Property> initial() const override {
             return makeRc<BoxSizingProperty>(self(), BoxSizing::CONTENT_BOX);
@@ -62,11 +60,7 @@ export struct BoxSizingProperty : Property {
 export struct WidthProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::WIDTH;
-        }
+            : Property::Registration(Properties::WIDTH, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<WidthProperty>(self(), Size{Keywords::AUTO});
@@ -106,11 +100,7 @@ export struct WidthProperty : Property {
 export struct HeightProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::HEIGHT;
-        }
+            : Property::Registration(Properties::HEIGHT, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<HeightProperty>(self(), Size{Keywords::AUTO});
@@ -148,9 +138,7 @@ export struct HeightProperty : Property {
 // https://www.w3.org/TR/css-sizing-3/#propdef-min-width
 export struct MinWidthProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MIN_WIDTH;
-        }
+        Registration() : Property::Registration(Properties::MIN_WIDTH) {}
 
         Rc<Property> initial() const override {
             return makeRc<MinWidthProperty>(self(), Size{Keywords::AUTO});
@@ -182,9 +170,7 @@ export struct MinWidthProperty : Property {
 // https://www.w3.org/TR/css-sizing-3/#propdef-min-height
 export struct MinHeightProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MIN_HEIGHT;
-        }
+        Registration() : Property::Registration(Properties::MIN_HEIGHT) {}
 
         Rc<Property> initial() const override {
             return makeRc<MinHeightProperty>(self(), Size{Keywords::AUTO});
@@ -217,9 +203,7 @@ export struct MinHeightProperty : Property {
 
 export struct MaxWidthProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MAX_WIDTH;
-        }
+        Registration() : Property::Registration(Properties::MAX_WIDTH) {}
 
         Rc<Property> initial() const override {
             return makeRc<MaxWidthProperty>(self(), MaxSize{Keywords::NONE});
@@ -251,9 +235,7 @@ export struct MaxWidthProperty : Property {
 // https://www.w3.org/TR/css-sizing-3/#propdef-max-height
 export struct MaxHeightProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::MAX_HEIGHT;
-        }
+        Registration() : Property::Registration(Properties::MAX_HEIGHT) {}
 
         Rc<Property> initial() const override {
             return makeRc<MaxHeightProperty>(self(), MaxSize{Keywords::NONE});

--- a/src/vaev-engine/props/svg.cpp
+++ b/src/vaev-engine/props/svg.cpp
@@ -19,11 +19,7 @@ namespace Vaev::Style {
 export struct SvgXProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::X;
-        }
+            : Property::Registration(Properties::X, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgXProperty>(self(), PercentOr<Length>{Length{0_au}});
@@ -60,11 +56,7 @@ export struct SvgXProperty : Property {
 export struct SvgYProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::Y;
-        }
+            : Property::Registration(Properties::Y, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgYProperty>(self(), PercentOr<Length>{Length{0_au}});
@@ -101,11 +93,7 @@ export struct SvgYProperty : Property {
 export struct SvgCXProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::CX;
-        }
+            : Property::Registration(Properties::CX, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgCXProperty>(self(), PercentOr<Length>{Length{0_au}});
@@ -142,11 +130,7 @@ export struct SvgCXProperty : Property {
 export struct SvgCYProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::CY;
-        }
+            : Property::Registration(Properties::CY, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgCYProperty>(self(), PercentOr<Length>{Length{0_au}});
@@ -183,11 +167,7 @@ export struct SvgCYProperty : Property {
 export struct SvgRProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::R;
-        }
+            : Property::Registration(Properties::R, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgRProperty>(self(), PercentOr<Length>{Length{0_au}});
@@ -224,11 +204,7 @@ export struct SvgRProperty : Property {
 export struct SvgFillProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
-
-        Symbol name() const override {
-            return Properties::FILL;
-        }
+            : Property::Registration(Properties::FILL, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgFillProperty>(self(), SvgPaint{Some(Color{Gfx::BLACK})});
@@ -270,11 +246,7 @@ export struct SvgFillProperty : Property {
 export struct SvgDProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::D;
-        }
+            : Property::Registration(Properties::D, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgDProperty>(self(), Union<String, None>{NONE});
@@ -335,11 +307,7 @@ export struct SvgDProperty : Property {
 export struct SvgViewBoxProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::VIEWBOX;
-        }
+            : Property::Registration(Properties::VIEWBOX, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgViewBoxProperty>(self(), Opt<SvgViewBox>{NONE});
@@ -385,11 +353,7 @@ export struct SvgViewBoxProperty : Property {
 export struct SvgStrokeProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
-
-        Symbol name() const override {
-            return Properties::STROKE;
-        }
+            : Property::Registration(Properties::STROKE, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgStrokeProperty>(self(), SvgPaint{NONE});
@@ -431,11 +395,7 @@ export struct SvgStrokeProperty : Property {
 export struct SvgStrokeOpacityProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::STROKE_OPACITY;
-        }
+            : Property::Registration(Properties::STROKE_OPACITY, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgStrokeOpacityProperty>(self(), Number{1});
@@ -482,11 +442,7 @@ export struct SvgStrokeOpacityProperty : Property {
 export struct FillOpacityProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
-
-        Symbol name() const override {
-            return Properties::FILL_OPACITY;
-        }
+            : Property::Registration(Properties::FILL_OPACITY, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<FillOpacityProperty>(self(), Number{1});
@@ -533,11 +489,7 @@ export struct FillOpacityProperty : Property {
 export struct StrokeWidthProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration({PRESENTATION_ATTRIBUTE, INHERITED}) {}
-
-        Symbol name() const override {
-            return Properties::STROKE_WIDTH;
-        }
+            : Property::Registration(Properties::STROKE_WIDTH, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<StrokeWidthProperty>(self(), PercentOr<Length>{Length{1_au}});

--- a/src/vaev-engine/props/table.cpp
+++ b/src/vaev-engine/props/table.cpp
@@ -16,9 +16,7 @@ namespace Vaev::Style {
 // https://www.w3.org/TR/CSS21/tables.html#propdef-table-layout
 export struct TableLayoutProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::TABLE_LAYOUT;
-        }
+        Registration() : Property::Registration(Properties::TABLE_LAYOUT) {}
 
         Rc<Property> initial() const override {
             return makeRc<TableLayoutProperty>(self(), TableLayout::AUTO);
@@ -51,11 +49,7 @@ export struct TableLayoutProperty : Property {
 export struct CaptionSideProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::CAPTION_SIDE;
-        }
+            : Property::Registration(Properties::CAPTION_SIDE, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<CaptionSideProperty>(self(), CaptionSide::TOP);

--- a/src/vaev-engine/props/text.cpp
+++ b/src/vaev-engine/props/text.cpp
@@ -21,11 +21,7 @@ namespace Vaev::Style {
 export struct TextAlignProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::TEXT_ALIGN;
-        }
+            : Property::Registration(Properties::TEXT_ALIGN, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<TextAlignProperty>(self(), TextAlign::LEFT);
@@ -85,11 +81,7 @@ export struct TextAlignProperty : Property {
 export struct TextTransformProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::TEXT_TRANSFORM;
-        }
+            : Property::Registration(Properties::TEXT_TRANSFORM, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<TextTransformProperty>(self(), TextTransform::NONE);
@@ -141,11 +133,7 @@ export struct TextTransformProperty : Property {
 export struct WhiteSpaceProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(INHERITED) {}
-
-        Symbol name() const override {
-            return Properties::WHITE_SPACE;
-        }
+            : Property::Registration(Properties::WHITE_SPACE, INHERITED) {}
 
         Rc<Property> initial() const override {
             return makeRc<WhiteSpaceProperty>(self(), WhiteSpace::NORMAL);

--- a/src/vaev-engine/props/transform.cpp
+++ b/src/vaev-engine/props/transform.cpp
@@ -20,11 +20,7 @@ namespace Vaev::Style {
 export struct TransformOriginProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::TRANSFORM_ORIGIN;
-        }
+            : Property::Registration(Properties::TRANSFORM_ORIGIN, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<TransformOriginProperty>(
@@ -62,9 +58,7 @@ export struct TransformOriginProperty : Property {
 // https://drafts.csswg.org/css-transforms/#transform-box
 export struct TransformBoxProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::TRANSFORM_BOX;
-        }
+        Registration() : Property::Registration(Properties::TRANSFORM_BOX) {}
 
         Rc<Property> initial() const override {
             return makeRc<TransformBoxProperty>(self(), TransformBox{Keywords::VIEW_BOX});
@@ -97,11 +91,7 @@ export struct TransformBoxProperty : Property {
 export struct TransformProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(PRESENTATION_ATTRIBUTE) {}
-
-        Symbol name() const override {
-            return Properties::TRANSFORM;
-        }
+            : Property::Registration(Properties::TRANSFORM, PRESENTATION_ATTRIBUTE) {}
 
         Rc<Property> initial() const override {
             return makeRc<TransformProperty>(self(), Transform{Keywords::NONE});

--- a/src/vaev-engine/props/visibility.cpp
+++ b/src/vaev-engine/props/visibility.cpp
@@ -16,9 +16,7 @@ namespace Vaev::Style {
 // https://drafts.csswg.org/css-display/#visibility
 export struct VisibilityProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::VISIBILITY;
-        }
+        Registration() : Property::Registration(Properties::VISIBILITY) {}
 
         Rc<Property> initial() const override {
             return makeRc<VisibilityProperty>(self(), Visibility::VISIBLE);
@@ -61,9 +59,7 @@ export struct VisibilityProperty : Property {
 // https://www.w3.org/TR/css-color-4/#propdef-opacity
 export struct OpacityProperty : Property {
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::OPACITY;
-        }
+        Registration() : Property::Registration(Properties::OPACITY) {}
 
         Rc<Property> initial() const override {
             return makeRc<OpacityProperty>(self(), Number{1});
@@ -101,9 +97,7 @@ export struct ClipPathProperty : Property {
     using Value = Union</* Url, */ BasicShape, Keywords::None>;
 
     struct Registration : Property::Registration {
-        Symbol name() const override {
-            return Properties::CLIP_PATH;
-        }
+        Registration() : Property::Registration(Properties::CLIP_PATH) {}
 
         Rc<Property> initial() const override {
             return makeRc<ClipPathProperty>(self(), Keywords::NONE);

--- a/src/vaev-engine/style/cascaded.cpp
+++ b/src/vaev-engine/style/cascaded.cpp
@@ -37,7 +37,7 @@ export struct CascadedValues {
     usize _declarationOrder = 0;
 
     void _putLonghand(Rc<Property> property, Origin origin, Specificity specificity, Css::Important important, usize declarationOrder) {
-        auto name = property->registration->name();
+        auto name = property->registration->name;
         Entry entry{property, important, origin, specificity, declarationOrder};
         auto& existing = _entries.lookupOrPutDefault(name, entry);
         if (entry >= existing)
@@ -65,7 +65,7 @@ export struct CascadedValues {
 
         for (auto& entry : shorthandEntries) {
             auto& prop = entry.property;
-            _entries.remove(prop->registration->name()).unwrap();
+            _entries.remove(prop->registration->name).unwrap();
             for (auto& longhandProperty : prop->expandShorthand(registeredPropertySet, parent, child)) {
                 _putLonghand(longhandProperty, entry.origin, entry.specificity, prop->important, entry.declarationOrder);
             }


### PR DESCRIPTION
Replace virtual `name()` methods with constructor-initialized name.

### Benchmark

with `hyperfine --warmup 1 --runs 5` on 2000 entry ledger

Before:
```
Time (mean ± σ):     23.240 s ±  0.643 s    [User: 23.097 s, System: 0.131 s]
Range (min … max):   22.868 s … 24.384 s    5 runs
```

After:
```
Time (mean ± σ):     22.795 s ±  0.220 s    [User: 22.642 s, System: 0.136 s]
Range (min … max):   22.660 s … 23.183 s    5 runs
```