### PR TITLE
vaev-dom: More compact el attribute storage inside.

### DIFF
--- a/src/utilities/html5lib-tests-runner/tree-construction.cpp
+++ b/src/utilities/html5lib-tests-runner/tree-construction.cpp
@@ -72,11 +72,10 @@ struct DocumentEmit {
 
             _indent();
 
-            auto attributes = element->attributes.iterItems() |
-                              Collect<Vec<Tuple<Dom::QualifiedName, Rc<Dom::Attr>>>>();
+            auto attributes = element->attributes;
 
             sort(attributes, [](auto const& a, auto const& b) {
-                return a.v0.name <=> b.v0.name;
+                return a.qualifiedName.name <=> b.qualifiedName.name;
             });
 
             for (usize i = 0; i < attributes.len(); i++) {
@@ -84,7 +83,7 @@ struct DocumentEmit {
 
                 try$(_emit("| "));
                 try$(_insertIndent());
-                try$(_emit("{}=\"{}\"\n", attribute.v0.name, attribute.v1->value));
+                try$(_emit("{}=\"{}\"\n", attribute.qualifiedName.name, attribute.value));
             }
 
             for (auto child = element->firstChild(); child; child = child->nextSibling()) {

--- a/src/vaev-browser/inspect.cpp
+++ b/src/vaev-browser/inspect.cpp
@@ -103,13 +103,13 @@ Ui::Child elementStartTag(Dom::Element const& el, bool expanded) {
 
     prose->pushSpan(prose->currentSpanStyle().withColor(Ui::ACCENT400));
 
-    for (auto [k, attr] : el.attributes.iterItems()) {
+    for (auto const& attr : el.attributes) {
         prose->append(" "s);
-        prose->append(Io::toStr(k));
+        prose->append(Io::toStr(attr.qualifiedName));
         prose->append("=\""s);
 
         prose->pushSpan(prose->currentSpanStyle().withColor(Gfx::AMBER500));
-        prose->append(attr->value);
+        prose->append(attr.value);
         prose->popSpan();
 
         prose->append("\""s);

--- a/src/vaev-engine/dom/attr.cpp
+++ b/src/vaev-engine/dom/attr.cpp
@@ -10,7 +10,7 @@ using namespace Karm;
 namespace Vaev::Dom {
 
 // https://dom.spec.whatwg.org/#interface-attr
-export struct Attr : Node {
+export struct Attr {
     QualifiedName qualifiedName;
     String value;
 
@@ -18,11 +18,7 @@ export struct Attr : Node {
         : qualifiedName(qualifiedName), value(value) {
     }
 
-    NodeType nodeType() const override {
-        return NodeType::ATTRIBUTE;
-    }
-
-    void _repr(Io::Emit& e) const override {
+    void repr(Io::Emit& e) const {
         e(" qualifiedName={} value={:#}", qualifiedName, value);
     }
 };

--- a/src/vaev-engine/dom/element.cpp
+++ b/src/vaev-engine/dom/element.cpp
@@ -65,7 +65,7 @@ export struct Element : Node {
 
     QualifiedName qualifiedName;
     // NOSPEC: Should be a NamedNodeMap
-    Map<QualifiedName, Rc<Attr>> attributes;
+    Vec<Attr> attributes;
     Opt<Rc<Style::ComputedValues>> _computedValues;
     TokenList classList;
     Opt<Gfx::Snapshot> imageContent;
@@ -86,8 +86,8 @@ export struct Element : Node {
         e(" qualifiedName={}", qualifiedName);
         if (this->attributes.len()) {
             e.indentNewline();
-            for (auto const& [name, attr] : this->attributes.iterItems()) {
-                attr->repr(e);
+            for (auto const& attr : this->attributes) {
+                attr.repr(e);
             }
             e.deindent();
         }
@@ -106,11 +106,11 @@ export struct Element : Node {
     // MARK: Attributes --------------------------------------------------------
 
     Opt<Str> id() const {
-        return getAttributeUnqualified("id"_sym);
+        return getAttributeUnqualified("id");
     }
 
     Opt<Str> style() const {
-        return getAttributeUnqualified("style"_sym);
+        return getAttributeUnqualified("style");
     }
 
     void setAttribute(QualifiedName name, String value) {
@@ -122,16 +122,29 @@ export struct Element : Node {
                 this->classList.add(class_);
             }
         }
-        this->attributes.put(name, makeRc<Attr>(name, value));
+
+        for (auto& attr : this->attributes) {
+            if (attr.qualifiedName == name) {
+                attr = Attr{name, value};
+                return;
+            }
+        }
+
+        this->attributes.emplaceBack(name, value);
     }
 
     bool hasAttribute(QualifiedName name) const {
-        return this->attributes.contains(name);
+        for (auto const& attr : this->attributes) {
+            if (attr.qualifiedName == name) {
+                return true;
+            }
+        }
+        return false;
     }
 
     bool hasAttributeUnqualified(Str name) const {
-        for (auto const& [qualifiedName, _] : this->attributes.iterItems()) {
-            if (qualifiedName.name.str() == name) {
+        for (auto const& attr : this->attributes) {
+            if (attr.qualifiedName.name == name) {
                 return true;
             }
         }
@@ -139,16 +152,16 @@ export struct Element : Node {
     }
 
     Opt<Str> getAttribute(QualifiedName name) const {
-        auto attr = this->attributes.lookup(name);
-        if (attr == NONE)
-            return NONE;
-        return Some((*attr)->value);
+        for (auto const& attr : this->attributes)
+            if (attr.qualifiedName == name)
+                return Some(attr.value);
+        return NONE;
     }
 
-    Opt<Str> getAttributeUnqualified(Symbol name) const {
-        for (auto const& [qualifiedName, attr] : this->attributes.iterItems())
-            if (qualifiedName.name == name)
-                return Some(attr->value);
+    Opt<Str> getAttributeUnqualified(Str name) const {
+        for (auto const& attr : this->attributes)
+            if (attr.qualifiedName.name == name)
+                return Some(attr.value);
         return NONE;
     }
 

--- a/src/vaev-engine/dom/serialisation.cpp
+++ b/src/vaev-engine/dom/serialisation.cpp
@@ -113,12 +113,12 @@ export void serializeHtmlFragment(Gc::Ref<Node> node, Io::Emit& e) {
                 e("\"");
             }
             // - For each attribute:
-            for (auto const& [qualifiedName, attr] : el->attributes.iterItems()) {
-                if (qualifiedName == Html::IS_ATTR)
+            for (auto const& attr : el->attributes) {
+                if (attr.qualifiedName == Html::IS_ATTR)
                     continue;
                 //     Append space, attribute’s serialized name, "=", quote, escaped value, quote.
-                e(" {}=\"", qualifiedName.name);
-                escapeString(e, attr->value, true);
+                e(" {}=\"", attr.qualifiedName.name);
+                escapeString(e, attr.value, true);
                 e("\"");
             }
             // - Append ">".

--- a/src/vaev-engine/html/parser.cpp
+++ b/src/vaev-engine/html/parser.cpp
@@ -220,15 +220,15 @@ struct _ActiveFormattingElementList {
 
             bool sameAttributes = entries[i].element()->attributes.len() == element->attributes.len();
             if (sameAttributes) {
-                for (auto const& [name, attr] : entries[i].element()->attributes.iterItems()) {
-                    auto other = element->getAttribute(name);
+                for (auto const& attr : entries[i].element()->attributes) {
+                    auto other = element->getAttribute(attr.qualifiedName);
 
                     if (not other) {
                         sameAttributes = false;
                         break;
                     }
 
-                    if (attr->value != *other) {
+                    if (attr.value != *other) {
                         sameAttributes = false;
                         break;
                     }

--- a/src/vaev-engine/style/computer.cpp
+++ b/src/vaev-engine/style/computer.cpp
@@ -342,8 +342,8 @@ export struct Computer {
         if (el->qualifiedName.ns != Svg::NAMESPACE)
             return;
 
-        for (auto [attr, attrValue] : el->attributes.iterItems())
-            if (auto const& [property] = _registeredPropertySet.parsePresentationAttribute(attr.name, attrValue->value))
+        for (auto const& attr : el->attributes)
+            if (auto const& [property] = _registeredPropertySet.parsePresentationAttribute(attr.qualifiedName.name, attr.value))
                 cascadedValues.put(property, Origin::AUTHOR_PRESENTATIONAL_HINT, PRESENTATION_HINT_SPEC);
 
         if (el->qualifiedName == Svg::SVG_TAG)

--- a/src/vaev-engine/style/matcher.cpp
+++ b/src/vaev-engine/style/matcher.cpp
@@ -143,7 +143,7 @@ static Opt<Str> _getAttributeValue(AttributeSelector const& selector, Gc::Ref<Do
         return NONE;
 
     if (selector.qualifiedName.ns.is<Universal>())
-        return element->getAttributeUnqualified(name.unwrap());
+        return element->getAttributeUnqualified(name.unwrap().str());
 
     return element->getAttribute(selector.qualifiedName.fullyQualified());
 }

--- a/src/vaev-engine/style/rules-index.cpp
+++ b/src/vaev-engine/style/rules-index.cpp
@@ -170,9 +170,9 @@ struct RuleIndex {
 
         considerCursorIfPresent(_typeNameRules, element->qualifiedName.name);
 
-        for (auto const& [name, value] : element->attributes.iterItems()) {
-            auto const& attrName = name.name;
-            auto key = Tuple{attrName, value->value.str()};
+        for (auto const& attr : element->attributes) {
+            auto const& attrName = attr.qualifiedName.name;
+            auto key = Tuple{attrName, attr.value.str()};
 
             considerCursorIfPresent(_attrPresentRules, attrName);
             considerCursorIfPresent(_attrExactValueRules, key);


### PR DESCRIPTION
```
metric                        before         after       change
Runtime mean                15.577 s      16.067 s       +3.15%
Runtime median              15.580 s      15.509 s       -0.46%
Allocations               12,617,950    12,657,736       +0.32%
Peak heap                  121.1 MiB     144.7 MiB      +19.48%
```
(the change is below the 'before' column)