### PR TITLE
vaev-style: Add bulk inheritance fastpaths.

### DIFF
--- a/src/vaev-engine/layout/base/fragment.cpp
+++ b/src/vaev-engine/layout/base/fragment.cpp
@@ -265,15 +265,15 @@ export struct SvgShapeFragment : Fragment {
         return objectBoundingBox();
     }
 
-    Opt<Gfx::Fill> resolveFill(SvgProps const& svg) {
-        if (Math::epsilonEq(svg.fillOpacity, 0.))
+    Opt<Gfx::Fill> resolveFill(Style::SvgPaintProps const& svgPaint) {
+        if (Math::epsilonEq(svgPaint.fillOpacity, 0.))
             return NONE;
 
-        if (not svg.fill)
+        if (not svgPaint.fill)
             return NONE;
 
-        if (auto [color] = resolve(svg.fill, style().color)) {
-            color = color.withOpacity(svg.fillOpacity);
+        if (auto [color] = resolve(svgPaint.fill, style().color)) {
+            color = color.withOpacity(svgPaint.fillOpacity);
             if (color.transparent())
                 return NONE;
             return Some(Gfx::Fill{color});
@@ -282,18 +282,18 @@ export struct SvgShapeFragment : Fragment {
         return NONE;
     }
 
-    Opt<Gfx::Stroke> resolveStroke(SvgProps const& svg) {
-        if (Math::epsilonEq(svg.strokeOpacity, 0.))
+    Opt<Gfx::Stroke> resolveStroke(Style::SvgPaintProps const& svgPaint) {
+        if (Math::epsilonEq(svgPaint.strokeOpacity, 0.))
             return NONE;
 
         if (strokeWidth == 0_au)
             return NONE;
 
-        if (not svg.stroke)
+        if (not svgPaint.stroke)
             return NONE;
 
-        if (auto [color] = resolve(svg.stroke, style().color)) {
-            color = color.withOpacity(svg.strokeOpacity);
+        if (auto [color] = resolve(svgPaint.stroke, style().color)) {
+            color = color.withOpacity(svgPaint.strokeOpacity);
             if (color.transparent())
                 return NONE;
 
@@ -312,7 +312,7 @@ export struct SvgShapeFragment : Fragment {
     void paintContent(Gfx::Canvas& g, Vec<OutOfBandOutline>& outOfBandOutlines) override {
         (void)outOfBandOutlines;
 
-        auto const& style = *originatingBox().style->svg;
+        auto const& style = *originatingBox().style->svgPaint;
 
         Opt<Gfx::Fill> resolvedFill = resolveFill(style);
         Opt<Gfx::Stroke> resolvedStroke = resolveStroke(style);

--- a/src/vaev-engine/layout/base/layout-impl.cpp
+++ b/src/vaev-engine/layout/base/layout-impl.cpp
@@ -87,7 +87,7 @@ Au _snapLengthAsBorderWidth(Au v) {
 
 InsetsAu computeBorders(Tree& tree, Box& box) {
     // NOTE: In borders collapse mode, we assume that the table box borders are 'transfered' to the cells
-    if (box.style->display == Display::TABLE_BOX and box.style->table->collapse == BorderCollapse::COLLAPSE) {
+    if (box.style->display == Display::TABLE_BOX and box.style->tableInherited->collapse == BorderCollapse::COLLAPSE) {
         return InsetsAu{};
     }
 

--- a/src/vaev-engine/layout/builder/mod.cpp
+++ b/src/vaev-engine/layout/builder/mod.cpp
@@ -757,7 +757,7 @@ static void _buildTableBox(BuilderContext tableWrapperBc, Gc::Ref<Dom::Element> 
 
     Box tableBox = {tableBoxStyle, Some(el)};
 
-    bool captionsOnTop = tableBoxStyle->table->captionSide == CaptionSide::TOP;
+    bool captionsOnTop = tableBoxStyle->tableInherited->captionSide == CaptionSide::TOP;
     if (captionsOnTop) {
         searchAndBuildCaption();
     }

--- a/src/vaev-engine/layout/svg.cpp
+++ b/src/vaev-engine/layout/svg.cpp
@@ -124,7 +124,7 @@ struct SvgFormatingContext : FormatingContext {
     }
 
     static void _commitShape(Box& box, FragmentBuilder& fragBuilder, Vec2Au relativeTo) {
-        Au resolvedStrokeWidth = Vaev::Layout::resolve(box.style->svg->strokeWidth, normalizedDiagonal(relativeTo));
+        Au resolvedStrokeWidth = Vaev::Layout::resolve(box.style->svgPaint->strokeWidth, normalizedDiagonal(relativeTo));
         auto shape = box.content.unwrap<SvgShapeElement>();
 
         switch (shape) {

--- a/src/vaev-engine/layout/table.cpp
+++ b/src/vaev-engine/layout/table.cpp
@@ -1300,12 +1300,12 @@ export struct TableFormatingContext : FormatingContext {
     bool useBordersCollapse = false;
 
     void build(Tree& tree, Box& box) override {
-        useBordersCollapse = box.style->table->collapse == BorderCollapse::COLLAPSE;
+        useBordersCollapse = box.style->tableInherited->collapse == BorderCollapse::COLLAPSE;
 
         if (not useBordersCollapse)
             spacing = {
-                resolve(tree, box, box.style->table->spacing.horizontal),
-                resolve(tree, box, box.style->table->spacing.vertical),
+                resolve(tree, box, box.style->tableInherited->spacing.horizontal),
+                resolve(tree, box, box.style->tableInherited->spacing.vertical),
             };
 
         buildHTMLTable(box);

--- a/src/vaev-engine/props/base.cpp
+++ b/src/vaev-engine/props/base.cpp
@@ -690,6 +690,11 @@ export struct RegisteredPropertySet {
     void inheritsComputedValues(ComputedValues const& parent, ComputedValues& child) const {
         // Apply defaulted inheritance fast path for property that supports it.
         child.customProps = parent.customProps;
+        child.font = parent.font;
+        child.list = parent.list;
+        child.text = parent.text;
+        child.svgPaint = parent.svgPaint;
+        child.tableInherited = parent.tableInherited;
 
         // Handle the rest of the properties
         for (auto& registration : _individuallyInherited)

--- a/src/vaev-engine/props/border.cpp
+++ b/src/vaev-engine/props/border.cpp
@@ -962,18 +962,14 @@ export struct BorderWidthProperty : Property {
 export struct BorderCollapseProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::BORDER_COLLAPSE, INHERITED) {}
+            : Property::Registration(Properties::BORDER_COLLAPSE, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderCollapseProperty>(self(), BorderCollapse::SEPARATE);
         }
 
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            child.table.cow().collapse = parent.table->collapse;
-        }
-
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<BorderCollapseProperty>(self(), c.table->collapse);
+            return makeRc<BorderCollapseProperty>(self(), c.tableInherited->collapse);
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -987,7 +983,7 @@ export struct BorderCollapseProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.table.cow().collapse = _value;
+        c.tableInherited.cow().collapse = _value;
     }
 
     void repr(Io::Emit& e) const override {
@@ -999,18 +995,14 @@ export struct BorderCollapseProperty : Property {
 export struct BorderSpacingProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::BORDER_SPACING, INHERITED) {}
+            : Property::Registration(Properties::BORDER_SPACING, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<BorderSpacingProperty>(self(), BorderSpacing{0_au, 0_au});
         }
 
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            child.table.cow().spacing = parent.table->spacing;
-        }
-
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<BorderSpacingProperty>(self(), c.table->spacing);
+            return makeRc<BorderSpacingProperty>(self(), c.tableInherited->spacing);
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -1024,7 +1016,7 @@ export struct BorderSpacingProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.table.cow().spacing = _value;
+        c.tableInherited.cow().spacing = _value;
     }
 
     void repr(Io::Emit& e) const override {

--- a/src/vaev-engine/props/fonts.cpp
+++ b/src/vaev-engine/props/fonts.cpp
@@ -19,7 +19,7 @@ namespace Vaev::Style {
 export struct FontFamilyProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::FONT_FAMILY, INHERITED) {}
+            : Property::Registration(Properties::FONT_FAMILY, {INHERITED, BULK_INHERITED}) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;
@@ -69,7 +69,7 @@ export struct FontFamilyProperty : Property {
 export struct FontWeightProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::FONT_WEIGHT, INHERITED) {}
+            : Property::Registration(Properties::FONT_WEIGHT, {INHERITED, BULK_INHERITED}) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;
@@ -110,7 +110,7 @@ export struct FontWeightProperty : Property {
 export struct FontWidthProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::FONT_WIDTH, INHERITED) {}
+            : Property::Registration(Properties::FONT_WIDTH, {INHERITED, BULK_INHERITED}) {}
 
         // https://drafts.csswg.org/css-fonts/#font-stretch-prop
         Vec<Symbol> legacyAlias() const override {
@@ -156,7 +156,7 @@ export struct FontWidthProperty : Property {
 export struct FontStyleProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::FONT_STYLE, INHERITED) {}
+            : Property::Registration(Properties::FONT_STYLE, {INHERITED, BULK_INHERITED}) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;
@@ -197,7 +197,7 @@ export struct FontStyleProperty : Property {
 export struct FontSizeProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::FONT_SIZE, INHERITED) {}
+            : Property::Registration(Properties::FONT_SIZE, {INHERITED, BULK_INHERITED}) {}
 
         ComputationPhase computationPhase() const override {
             return ComputationPhase::FONT;

--- a/src/vaev-engine/props/list.cpp
+++ b/src/vaev-engine/props/list.cpp
@@ -12,7 +12,7 @@ namespace Vaev::Style {
 struct ListStyleImageProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::LIST_STYLE_IMAGE, INHERITED) {}
+            : Property::Registration(Properties::LIST_STYLE_IMAGE, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<ListStyleImageProperty>(self(), Keywords::NONE);
@@ -50,7 +50,7 @@ struct ListStyleImageProperty : Property {
 struct ListStyleTypeProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::LIST_STYLE_TYPE, INHERITED) {}
+            : Property::Registration(Properties::LIST_STYLE_TYPE, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<ListStyleTypeProperty>(self(), CustomIdent{"disc"_sym});
@@ -88,7 +88,7 @@ struct ListStyleTypeProperty : Property {
 struct ListStylePositionProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::LIST_STYLE_POSITION, INHERITED) {}
+            : Property::Registration(Properties::LIST_STYLE_POSITION, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<ListStylePositionProperty>(self(), Keywords::OUTSIDE);
@@ -208,7 +208,7 @@ struct ListStyleProperty : Property {
 struct MarkerSideProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::MARKER_SIDE, INHERITED) {}
+            : Property::Registration(Properties::MARKER_SIDE, {INHERITED, BULK_INHERITED}) {}
 
         void inherit(ComputedValues const& parent, ComputedValues& child) const override {
             child.list.cow().markerSide = parent.list->markerSide;

--- a/src/vaev-engine/props/svg.cpp
+++ b/src/vaev-engine/props/svg.cpp
@@ -204,23 +204,14 @@ export struct SvgRProperty : Property {
 export struct SvgFillProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::FILL, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
+            : Property::Registration(Properties::FILL, {PRESENTATION_ATTRIBUTE, INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgFillProperty>(self(), SvgPaint{Some(Color{Gfx::BLACK})});
         }
 
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            // NOTE: We bail out early if the parent has the default SVG values.
-            //       This avoids needlessly writing into the child's style, which would
-            //       trigger a copy-on-write of the whole property group for nothing.
-            if (parent.svg.defaulted())
-                return;
-            child.svg.cow().fill = parent.svg->fill;
-        }
-
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<SvgFillProperty>(self(), SvgPaint{c.svg->fill});
+            return makeRc<SvgFillProperty>(self(), SvgPaint{c.svgPaint->fill});
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -234,7 +225,7 @@ export struct SvgFillProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.svg.cow().fill = _value;
+        c.svgPaint.cow().fill = _value;
     }
 
     void repr(Io::Emit& e) const override {
@@ -353,23 +344,14 @@ export struct SvgViewBoxProperty : Property {
 export struct SvgStrokeProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::STROKE, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
+            : Property::Registration(Properties::STROKE, {PRESENTATION_ATTRIBUTE, INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgStrokeProperty>(self(), SvgPaint{NONE});
         }
 
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            // NOTE: We bail out early if the parent has the default SVG values.
-            //       This avoids needlessly writing into the child's style, which would
-            //       trigger a copy-on-write of the whole property group for nothing.
-            if (parent.svg.defaulted())
-                return;
-            child.svg.cow().stroke = parent.svg->stroke;
-        }
-
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<SvgStrokeProperty>(self(), SvgPaint{c.svg->stroke});
+            return makeRc<SvgStrokeProperty>(self(), SvgPaint{c.svgPaint->stroke});
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -383,7 +365,7 @@ export struct SvgStrokeProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.svg.cow().stroke = _value;
+        c.svgPaint.cow().stroke = _value;
     }
 
     void repr(Io::Emit& e) const override {
@@ -395,23 +377,14 @@ export struct SvgStrokeProperty : Property {
 export struct SvgStrokeOpacityProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::STROKE_OPACITY, INHERITED) {}
+            : Property::Registration(Properties::STROKE_OPACITY, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<SvgStrokeOpacityProperty>(self(), Number{1});
         }
 
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<SvgStrokeOpacityProperty>(self(), c.svg->strokeOpacity);
-        }
-
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            // NOTE: We bail out early if the parent has the default SVG values.
-            //       This avoids needlessly writing into the child's style, which would
-            //       trigger a copy-on-write of the whole property group for nothing.
-            if (parent.svg.defaulted())
-                return;
-            child.svg.cow().strokeOpacity = parent.svg->strokeOpacity;
+            return makeRc<SvgStrokeOpacityProperty>(self(), c.svgPaint->strokeOpacity);
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -430,7 +403,7 @@ export struct SvgStrokeOpacityProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.svg.cow().strokeOpacity = _value;
+        c.svgPaint.cow().strokeOpacity = _value;
     }
 
     void repr(Io::Emit& e) const override {
@@ -442,23 +415,14 @@ export struct SvgStrokeOpacityProperty : Property {
 export struct FillOpacityProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::FILL_OPACITY, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
+            : Property::Registration(Properties::FILL_OPACITY, {PRESENTATION_ATTRIBUTE, INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<FillOpacityProperty>(self(), Number{1});
         }
 
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<FillOpacityProperty>(self(), c.svg->fillOpacity);
-        }
-
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            // NOTE: We bail out early if the parent has the default SVG values.
-            //       This avoids needlessly writing into the child's style, which would
-            //       trigger a copy-on-write of the whole property group for nothing.
-            if (parent.svg.defaulted())
-                return;
-            child.svg.cow().fillOpacity = parent.svg->fillOpacity;
+            return makeRc<FillOpacityProperty>(self(), c.svgPaint->fillOpacity);
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -477,7 +441,7 @@ export struct FillOpacityProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.svg.cow().fillOpacity = _value;
+        c.svgPaint.cow().fillOpacity = _value;
     }
 
     void repr(Io::Emit& e) const override {
@@ -489,19 +453,10 @@ export struct FillOpacityProperty : Property {
 export struct StrokeWidthProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::STROKE_WIDTH, {PRESENTATION_ATTRIBUTE, INHERITED}) {}
+            : Property::Registration(Properties::STROKE_WIDTH, {PRESENTATION_ATTRIBUTE, INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<StrokeWidthProperty>(self(), PercentOr<Length>{Length{1_au}});
-        }
-
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            // NOTE: We bail out early if the parent has the default SVG values.
-            //       This avoids needlessly writing into the child's style, which would
-            //       trigger a copy-on-write of the whole property group for nothing.
-            if (parent.svg.defaulted())
-                return;
-            child.svg.cow().strokeWidth = parent.svg->strokeWidth;
         }
 
         Res<Rc<Property>> parsePresentationAttribute(Str style) override {
@@ -509,7 +464,7 @@ export struct StrokeWidthProperty : Property {
         }
 
         Rc<Property> load(ComputedValues const& c) const override {
-            return makeRc<StrokeWidthProperty>(self(), c.svg->strokeWidth);
+            return makeRc<StrokeWidthProperty>(self(), c.svgPaint->strokeWidth);
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -523,7 +478,7 @@ export struct StrokeWidthProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.svg.cow().strokeWidth = _value;
+        c.svgPaint.cow().strokeWidth = _value;
     }
 
     void repr(Io::Emit& e) const override {

--- a/src/vaev-engine/props/table.cpp
+++ b/src/vaev-engine/props/table.cpp
@@ -49,18 +49,14 @@ export struct TableLayoutProperty : Property {
 export struct CaptionSideProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::CAPTION_SIDE, INHERITED) {}
+            : Property::Registration(Properties::CAPTION_SIDE, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<CaptionSideProperty>(self(), CaptionSide::TOP);
         }
 
-        void inherit(ComputedValues const& parent, ComputedValues& child) const override {
-            child.table.cow().captionSide = parent.table->captionSide;
-        }
-
         Rc<Property> load(ComputedValues const& s) const override {
-            return makeRc<CaptionSideProperty>(self(), s.table->captionSide);
+            return makeRc<CaptionSideProperty>(self(), s.tableInherited->captionSide);
         }
 
         Res<Rc<Property>> parse(Cursor<Css::Sst>& c) const override {
@@ -74,7 +70,7 @@ export struct CaptionSideProperty : Property {
         : Property(registration), _value(value) {}
 
     void apply([[maybe_unused]] ComputedValues const& parent, ComputedValues& c, [[maybe_unused]] ComputationContext const& cx) const override {
-        c.table.cow().captionSide = _value;
+        c.tableInherited.cow().captionSide = _value;
     }
 
     void repr(Io::Emit& e) const override {

--- a/src/vaev-engine/props/text.cpp
+++ b/src/vaev-engine/props/text.cpp
@@ -21,7 +21,7 @@ namespace Vaev::Style {
 export struct TextAlignProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::TEXT_ALIGN, INHERITED) {}
+            : Property::Registration(Properties::TEXT_ALIGN, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<TextAlignProperty>(self(), TextAlign::LEFT);
@@ -81,7 +81,7 @@ export struct TextAlignProperty : Property {
 export struct TextTransformProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::TEXT_TRANSFORM, INHERITED) {}
+            : Property::Registration(Properties::TEXT_TRANSFORM, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<TextTransformProperty>(self(), TextTransform::NONE);
@@ -133,7 +133,7 @@ export struct TextTransformProperty : Property {
 export struct WhiteSpaceProperty : Property {
     struct Registration : Property::Registration {
         Registration()
-            : Property::Registration(Properties::WHITE_SPACE, INHERITED) {}
+            : Property::Registration(Properties::WHITE_SPACE, {INHERITED, BULK_INHERITED}) {}
 
         Rc<Property> initial() const override {
             return makeRc<WhiteSpaceProperty>(self(), WhiteSpace::NORMAL);

--- a/src/vaev-engine/style/computed.cpp
+++ b/src/vaev-engine/style/computed.cpp
@@ -32,6 +32,39 @@ struct TransformProps {
     }
 };
 
+
+export struct TableProps {
+    TableLayout tableLayout = TableLayout::AUTO;
+    usize span = 1;
+    usize rowSpan = 1;
+    usize colSpan = 1;
+};
+
+export struct TableInheritedProps {
+    CaptionSide captionSide = CaptionSide::TOP;
+    BorderSpacing spacing = {0_au, 0_au};
+    BorderCollapse collapse = BorderCollapse::SEPARATE;
+};
+
+export struct SvgProps {
+    PercentOr<Length> x = Length{0_au};
+    PercentOr<Length> y = Length{0_au};
+    PercentOr<Length> cx = Length{0_au};
+    PercentOr<Length> cy = Length{0_au};
+    PercentOr<Length> r = Length{0_au};
+
+    Union<String, None> d = NONE;
+    Opt<SvgViewBox> viewBox = NONE;
+};
+
+export struct SvgPaintProps {
+    Number fillOpacity = 1;
+    PercentOr<Length> strokeWidth = Length{1_au};
+    Number strokeOpacity = 1;
+    SvgPaint fill = Some(Gfx::BLACK);
+    SvgPaint stroke = NONE;
+};
+
 using ClipProps = Opt<BasicShape>;
 
 export struct Inherited {};
@@ -50,11 +83,13 @@ export struct ComputedValues {
     Cow<ClipProps> clip;
     Cow<TransformProps> transform;
     Cow<TableProps> table;
+    Cow<TableInheritedProps> tableInherited;
     Cow<FontProps> font;
     Cow<TextProps> text;
     Cow<FlexProps> flex;
     Cow<BreakProps> break_;
     Cow<SvgProps> svg;
+    Cow<SvgPaintProps> svgPaint;
     Cow<CounterProps> counters;
     Cow<ListProps> list;
 

--- a/src/vaev-engine/values/svg.cpp
+++ b/src/vaev-engine/values/svg.cpp
@@ -73,38 +73,6 @@ enum struct SvgShapeElement {
     _LEN
 };
 
-export struct SvgProps {
-    PercentOr<Length> x = Length{0_au};
-    PercentOr<Length> y = Length{0_au};
-    PercentOr<Length> cx = Length{0_au};
-    PercentOr<Length> cy = Length{0_au};
-    PercentOr<Length> r = Length{0_au};
-
-    Number fillOpacity = 1;
-    PercentOr<Length> strokeWidth = Length{1_au};
-    Number strokeOpacity = 1;
-    Union<String, None> d = NONE;
-    SvgPaint fill = Some(Gfx::BLACK);
-    SvgPaint stroke = NONE;
-    Opt<SvgViewBox> viewBox = NONE;
-
-    void repr(Io::Emit& e) const {
-        e("(svg");
-        e(" x={}", x);
-        e(" y={}", y);
-        e(" cx={}", cx);
-        e(" cy={}", cy);
-        e(" r={}", r);
-        e(" fillOpacity={}", fillOpacity);
-        e(" strokeWidth={}", strokeWidth);
-        e(" d={}", d);
-        e(" fill={}", fill);
-        e(" stroke={}", stroke);
-        e(" viewBox={}", viewBox);
-        e(")");
-    }
-};
-
 // MARK: Paint
 // https://svgwg.org/svg2-draft/painting.html#SpecifyingPaint
 export template <>

--- a/src/vaev-engine/values/table.cpp
+++ b/src/vaev-engine/values/table.cpp
@@ -123,26 +123,4 @@ struct ValueParser<BorderSpacing> {
     }
 };
 
-export struct TableProps {
-    TableLayout tableLayout = TableLayout::AUTO;
-    CaptionSide captionSide = CaptionSide::TOP;
-    BorderSpacing spacing = {0_au, 0_au};
-    BorderCollapse collapse = BorderCollapse::SEPARATE;
-    usize span = 1;
-    usize rowSpan = 1;
-    usize colSpan = 1;
-
-    void repr(Io::Emit& e) const {
-        e("(table");
-        e(" tableLayout={}", tableLayout);
-        e(" captionSide={}", captionSide);
-        e(" spacing={}", spacing);
-        e(" collapse={}", collapse);
-        e(" span={}", span);
-        e(" rowSpan={}", rowSpan);
-        e(" colSpan={}", colSpan);
-        e(")");
-    }
-};
-
 } // namespace Vaev


### PR DESCRIPTION
```
metric                   before-bulk      after-bulk     change
Runtime mean                16.189 s      15.141 s       -6.48%
Runtime median              15.982 s      14.714 s       -7.93%
Allocations               12,617,955     8,774,397      -30.46%
Peak heap                  121.1 MiB      96.8 MiB      -20.10%
```