### PR TITLE
vaev-layout: Cache auto table sizing across fragments.

### DIFF
--- a/src/vaev-engine/layout/table.cpp
+++ b/src/vaev-engine/layout/table.cpp
@@ -913,7 +913,6 @@ export struct TableFormatingContext : FormatingContext {
             }
         }
 
-        // Resize the column-width vector and update it in place with the resolved widths.
         colWidth.resize(colWidthOrNone.len());
         for (usize i = 0; i < grid.size.x; ++i) {
             colWidth[i] = colWidthOrNone[i].unwrapOr(0_au);
@@ -1283,18 +1282,24 @@ export struct TableFormatingContext : FormatingContext {
     Math::Vec2u dataRowsInterval;
     Vec<Au> startPositionOfRow;
 
-    struct CacheParametersFromInput {
+    struct AutoLayoutCacheKey {
         Au containingBlockX;
-        Au capmin;
-        Opt<Au> knownSizeX;
+        Opt<Au> capmin;
+        Opt<Au> knownWidth;
+        Opt<Au> knownHeight;
+        IntrinsicSize intrinsic;
+        bool discovery;
 
-        CacheParametersFromInput(Input const& i)
-            : containingBlockX(i.containingBlock.x),
-              capmin(i.capmin.unwrap()),
-              knownSizeX(i.knownSize.width) {
+        AutoLayoutCacheKey(Input const& input, bool discovery)
+            : containingBlockX(input.containingBlock.x),
+              capmin(input.capmin),
+              knownWidth(input.knownSize.width),
+              knownHeight(input.knownSize.height),
+              intrinsic(input.intrinsic),
+              discovery(discovery) {
         }
 
-        bool operator==(CacheParametersFromInput const& c) const = default;
+        bool operator==(AutoLayoutCacheKey const&) const = default;
     };
 
     bool useBordersCollapse = false;
@@ -1321,7 +1326,7 @@ export struct TableFormatingContext : FormatingContext {
         dataRowsInterval = {numOfHeaderRows, grid.size.y - numOfFooterRows - 1};
     }
 
-    Opt<CacheParametersFromInput> lastInput;
+    Opt<AutoLayoutCacheKey> lastAutoLayoutInput;
 
     void computeWidthAndHeight(Tree& tree, Box& box, Input const& input) {
         // NOTE: When "table-layout: fixed" is set but "width: auto", the specs suggest
@@ -1332,15 +1337,24 @@ export struct TableFormatingContext : FormatingContext {
         bool shouldRunAutoAlgorithm =
             box.style->table->tableLayout == TableLayout::AUTO or
             not input.knownSize.width;
+        Opt<AutoLayoutCacheKey> cacheKey;
 
         if (shouldRunAutoAlgorithm) {
+            cacheKey = Some(AutoLayoutCacheKey{
+                input,
+                tree.fc.isDiscoveryMode(),
+            });
+
+            if (lastAutoLayoutInput == cacheKey)
+                return;
+
             if (input.intrinsic == IntrinsicSize::AUTO) {
-                CacheParametersFromInput inputCacheParameters{input};
-                if (lastInput != inputCacheParameters) {
-                    lastInput = Some(inputCacheParameters);
-                    // bad code
-                    computeAutoColWidths(tree, input.knownSize.width, input.capmin.unwrapOr(0_au), input.containingBlock.x);
-                }
+                computeAutoColWidths(
+                    tree,
+                    input.knownSize.width,
+                    input.capmin.unwrapOr(0_au),
+                    input.containingBlock.x
+                );
             } else {
                 auto [minContent, maxContent] = computeIntrinsicMinMaxAutoWidths(tree, grid.size.x);
                 if (input.intrinsic == IntrinsicSize::MIN_CONTENT)
@@ -1357,6 +1371,8 @@ export struct TableFormatingContext : FormatingContext {
             computeFixedColWidths(tree, box, *input.knownSize.width);
         }
 
+        numAutoHeightRows = 0;
+        totalNonAutoHeight = 0_au;
         computeRowHeights(tree);
 
         auto usedVerticalSpace = (iter(rowHeight) | Sum()) + spacing.y * (grid.size.y + 1);
@@ -1403,6 +1419,8 @@ export struct TableFormatingContext : FormatingContext {
                     spacing.y * (numOfFooterRows + 1),
             };
         }
+
+        lastAutoLayoutInput = cacheKey;
     }
 
     UsedBorders buildUsedCollapsedBordersForCell(usize i, usize j, usize rowSpan, usize colSpan) {

--- a/src/vaev-engine/layout/table.cpp
+++ b/src/vaev-engine/layout/table.cpp
@@ -913,10 +913,10 @@ export struct TableFormatingContext : FormatingContext {
             }
         }
 
-        colWidth.ensure(colWidthOrNone.len());
+        // Resize the column-width vector and update it in place with the resolved widths.
+        colWidth.resize(colWidthOrNone.len());
         for (usize i = 0; i < grid.size.x; ++i) {
-            auto finalColWidth = colWidthOrNone[i].unwrapOr(0_au);
-            colWidth.pushBack(finalColWidth);
+            colWidth[i] = colWidthOrNone[i].unwrapOr(0_au);
         }
     }
 

--- a/src/vaev-engine/style/computed.cpp
+++ b/src/vaev-engine/style/computed.cpp
@@ -32,7 +32,6 @@ struct TransformProps {
     }
 };
 
-
 export struct TableProps {
     TableLayout tableLayout = TableLayout::AUTO;
     usize span = 1;

--- a/tests/css/break/page.xhtml
+++ b/tests/css/break/page.xhtml
@@ -306,4 +306,30 @@
 
 </test>
 
+<test name="table row-height cache pagination" flow="paginate" margins="minimum">
+    <container>
+        <html xmlns="http://www.w3.org/1999/xhtml">
+        <head>
+            <style>
+                @page { size: 100px 100px; margin: 0; }
+                html, body { margin: 0; }
+                table { width: 100px; border-spacing: 0; background: red; }
+                td { padding: 0; }
+                .part { height: 120px; }
+            </style>
+        </head>
+        <body><slot /></body>
+        </html>
+    </container>
+
+    <rendering help="fragmented table cell">
+        <table><tr><td><div class="part"></div><div class="part"></div></td></tr></table>
+    </rendering>
+
+    <rendering help="reference">
+        <div style="width:100px;height:200px;background:red"></div>
+        <div style="width:100px;height:120px;background:red"></div>
+    </rendering>
+</test>
+
 </tests>


### PR DESCRIPTION
Cache the auto table sizing pass across fragments when its inputs remain unchanged. Tracking discovery prevents measurements collected while finding breakpoints from being reused during rendering.

## Benchmarks
### curve
Before:
<img width="1200" height="600" alt="before" src="https://github.com/user-attachments/assets/fe6f13bf-68e0-44eb-9b37-892c706a977c" />

After:
<img width="1200" height="600" alt="after" src="https://github.com/user-attachments/assets/8b98db7b-512b-46f9-9bc5-faed4723c34b" />

### paper-bencher
ran 'paper-bencher' with 2000 entry ledger and default configs.

```
metric                        base         after         change
Runtime mean                20.427 s      12.206 s      -40.24%
Runtime median              20.435 s      11.920 s      -41.67%
Allocations                8,775,498     6,911,754      -21.24%
Peak heap                   96.8 MiB      96.8 MiB       +0.01%
```